### PR TITLE
Integrate with client-service-associations

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -402,6 +402,7 @@
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/canI.js"></script>
         <script src="scripts/filters/util.js"></script>
+        <script src="scripts/filters/mobile.js"></script>
         <script src="scripts/services/logLinks.js"></script>
 
         <!-- add bundled extensions here -->

--- a/app/scripts/directives/mobileClientConfig.js
+++ b/app/scripts/directives/mobileClientConfig.js
@@ -13,50 +13,72 @@ angular.module('openshiftConsole').component('mobileClientConfig', {
       MobileClientConfigCtrl]
   });
 
+var filterExcludedServices = function(serviceInstances, mobileClient) {
+  return _.filter(serviceInstances, function(service, serviceName){
+    return _.indexOf(_.get(mobileClient, 'spec.excludedServices'), serviceName) === -1;
+  });
+};
+
+var getServiceConfig = function(configmaps, services) {
+  return _(configmaps.by('metadata.name'))
+  .filter(function(configmap) {
+    return  _.findIndex(services, {metadata: {labels: {serviceName: _.get(configmap, 'metadata.name')}}}) !== -1;
+  })
+  .map(function(configmap) {
+    return {
+      id: _.get(configmap, 'metadata.name'),
+      name: _.get(configmap, 'metadata.name'),
+      type: configmap.data.type,
+      url: configmap.data.uri,
+      config: configmap.data
+    };
+  }).value();
+};
+
+var getClientConfig = function(mobileClient, serviceConfig, clusterInfo) {
+  return JSON.stringify({
+    version: 1,
+    clusterName: clusterInfo.openshift.hostPort,
+    namespace: _.get(mobileClient, 'metadata.namespace'),
+    clientId: _.get(mobileClient, 'metadata.name'),
+    services: serviceConfig
+  }, null, '  ');
+};
+
 function MobileClientConfigCtrl(APIService, DataService, API_CFG) {
   var ctrl = this;
   var watches = [];
   ctrl.$onInit = function(){
-    var context = {namespace: _.get(ctrl, "mobileClient.metadata.namespace")};
+    var context = {namespace: _.get(ctrl, 'mobileClient.metadata.namespace')};
     //keep list of active services upto date
     DataService.watch(
       APIService.getPreferredVersion('serviceinstances'), 
       context, 
       function (serviceinstances){
-        ctrl.services = _.filter(serviceinstances.by("metadata.name"), function(service, serviceName){
-          return _.indexOf(ctrl.mobileClient.spec.excludedServices, serviceName) === -1;
-        });
-        DataService.list(APIService.getPreferredVersion('configmaps'), context, updateConfig, {errorNotification: false});
+        ctrl.services = serviceinstances.by('metadata.name');
+        DataService.list(APIService.getPreferredVersion('configmaps'), context, updateClientConfig, {errorNotification: false});
       }, 
       { errorNotification: false }
     );
-    watches.push(DataService.watch(APIService.getPreferredVersion('configmaps'), context, updateConfig, {errorNotification: false}));
+    watches.push(DataService.watch(APIService.getPreferredVersion('configmaps'), context, updateClientConfig, {errorNotification: false}));
 
     // update the config string by pulling out configmaps that match ctrl.services
-    function updateConfig(configmaps){
-      var configs =_(configmaps.by("metadata.name"))
-      .filter(function(configmap) {
-        return  _.findIndex(ctrl.services, {metadata: {labels: {serviceName: _.get(configmap, "metadata.name")}}}) !== -1;
-      })
-      .map(function(configmap) {
-        return {
-          id: _.get(configmap, "metadata.name"),
-          name: _.get(configmap, "metadata.name"),
-          type: configmap.data.type,
-          url: configmap.data.uri,
-          config: configmap.data
-        };
-      }).value();
-      ctrl.prettyConfig = JSON.stringify({
-        version: 1,
-        clusterName: API_CFG.openshift.hostPort,
-        namespace: _.get(ctrl, "mobileClient.metadata.namespace"),
-        clientId: _.get(ctrl, "mobileClient.metadata.name"),
-        services: configs
-      }, null, "  ");
+    function updateClientConfig(configmaps){
+      ctrl.configmaps = configmaps;
+      var services = filterExcludedServices(ctrl.services, ctrl.mobileClient);
+      ctrl.serviceConfig = getServiceConfig(configmaps, services);
+      ctrl.prettyConfig = getClientConfig(ctrl.mobileClient, ctrl.serviceConfig, API_CFG);
     }
   };
   
+  ctrl.$onChanges = function(changes) {
+    if (changes.mobileClient && ctrl.configmaps && ctrl.services) {
+      var services = filterExcludedServices(ctrl.services, ctrl.mobileClient);
+      ctrl.serviceConfig = getServiceConfig(ctrl.configmaps, services);
+      ctrl.prettyConfig = getClientConfig(ctrl.mobileClient, ctrl.serviceConfig, API_CFG);
+    }
+  };
+
   ctrl.$onDestroy = function() {
     DataService.unwatchAll(watches);
   };

--- a/app/scripts/filters/mobile.js
+++ b/app/scripts/filters/mobile.js
@@ -1,0 +1,8 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .filter('isMobileService', function() {
+    return function(serviceInstance) {
+      return _.get(serviceInstance, 'metadata.labels.mobile') === 'enabled';
+    };
+  });

--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -651,4 +651,12 @@
       }
     }
   }
+
+  .mobile-row {
+    .copy-to-clipboard {
+      pre {
+        height: 250px;
+      }
+    }
+  }
 }

--- a/app/styles/_overview.less
+++ b/app/styles/_overview.less
@@ -655,7 +655,7 @@
   .mobile-row {
     .copy-to-clipboard {
       pre {
-        height: 250px;
+        max-height: 250px;
       }
     }
   }

--- a/app/views/overview/_mobile-client-row.html
+++ b/app/views/overview/_mobile-client-row.html
@@ -1,4 +1,4 @@
-<div class="list-pf-item" ng-class="{ active: row.expanded }">
+<div class="list-pf-item mobile-row" ng-class="{ active: row.expanded }">
   <div class="list-pf-container" ng-click="row.toggleExpand($event)">
     <div class="list-pf-chevron">
       <div ng-include src=" 'views/overview/_list-row-chevron.html' " class="list-pf-content"></div>
@@ -37,22 +37,28 @@
   </div>
   <div class="list-pf-expansion collapse" ng-if="row.expanded" ng-class="{ in: row.expanded }">
     <div class="list-pf-container">
-      <div class="expanded-section row">
-        <div class="col-md-5">
-          <mobile-client-config mobile-client="row.apiObject"></mobile-client-config>
-        </div>
-        <div class="col-md-7">
-        </div>
-        <div class="col-md-12">
+      <div class="expanded-section" ng-if="!(row.services | size)">
+        <div class="empty-state-message text-center">
           <p>Add a mobile service to your project. Or connect to external service.</p>
           <div class="empty-state-message-main-action">
-            <button class="btn btn-primary btn-lg" ng-click="row.browseCatalog()">Browse Mobile Services
+            <!--TODO link through to the mobile category -->
+            <button class="btn btn-primary btn-lg" ng-click="row.browseCatalog()">
+              Browse Mobile Services
             </button>
           </div>
-          <div ng-if="loading">
-            Loading...
+        </div>
+      </div>
+      <div class="expanded-section" ng-if="(row.services | size)">
+        <div class="row">
+          <div class="col-md-4">
+            <mobile-client-config mobile-client="row.apiObject"></mobile-client-config>
+          </div>
+          <div class="col-md-8">
           </div>
         </div>
+      </div>
+      <div ng-if="loading">
+        Loading...
       </div>
     </div>
   </div>


### PR DESCRIPTION
@philbrookes These are the changes needed to integrate with the [mobile-associations work](https://github.com/aerogear/origin-web-console/pull/20) 

- Added a watch for mobile client changes as a service can be excluded/added which affects the config
- We are keeping the current mobile row landing view which shows the button to go to mobile catalog if no services are avaialble.
- Small styling (height and positioning) of the config component