### PR TITLE
Set watch in onChanges

### DIFF
--- a/app/views/overview/_mobile-client-row.html
+++ b/app/views/overview/_mobile-client-row.html
@@ -51,7 +51,7 @@
       <div class="expanded-section" ng-if="(row.services | size)">
         <div class="row">
           <div class="col-md-4">
-            <mobile-client-config mobile-client="row.apiObject" project-name="row.context.namespace"></mobile-client-config>
+            <mobile-client-config mobile-client="row.apiObject"></mobile-client-config>
           </div>
           <div class="col-md-8">
           </div>


### PR DESCRIPTION
@witmicko @philbrookes 
These are some changes I have from integrating the component with the client view.
The mobileClient isn't ready when the secrets watch is initialized within `$onInit` so I have moved it to `$onChanges`. 