### PR TITLE
Display integrated services on service instance

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -361,6 +361,7 @@
         <script src="scripts/directives/buildPipeline.js"></script>
         <script src="scripts/directives/buildStatus.js"></script>
         <script src="scripts/directives/routeServiceBarChart.js"></script>
+        <script src="scripts/directives/mobileServiceClients.js"></script>
         <script src="scripts/directives/bindService.js"></script>
         <script src="scripts/directives/unbindService.js"></script>
         <script src="scripts/directives/processTemplate.js"></script>
@@ -404,6 +405,7 @@
         <script src="scripts/filters/resources.js"></script>
         <script src="scripts/filters/canI.js"></script>
         <script src="scripts/filters/util.js"></script>
+        <script src="scripts/filters/mobile.js"></script>
         <script src="scripts/services/logLinks.js"></script>
 
         <!-- add bundled extensions here -->

--- a/app/scripts/directives/mobileServiceClients.js
+++ b/app/scripts/directives/mobileServiceClients.js
@@ -1,0 +1,56 @@
+'use strict';
+
+(function() {
+  angular.module('openshiftConsole').component('mobileServiceClients', {
+    controller: [
+      'APIService',
+      'DataService',
+      MobileServiceClientsCtrl
+    ],
+    bindings: {
+      project: '<',
+      serviceInstance: '<',
+      mobileClients: '<'
+    },
+    templateUrl: 'views/directives/mobile-service-clients.html'
+  });
+
+  function MobileServiceClientsCtrl(
+    APIService,
+    DataService
+  ) {
+    var ctrl = this;
+    var watches = [];
+    var bindingPreferredVersion = APIService.getPreferredVersion('servicebindings');
+
+    ctrl.$onChanges = function(changes) {
+      if (changes.mobileClients && changes.mobileClients.currentValue) {
+        ctrl.clientNames = _.map(ctrl.mobileClients, function(client) {
+          return _.get(client, 'metadata.name');
+        });
+      }
+
+      if (changes.mobileClients && changes.mobileClients.currentValue &&
+          changes.serviceInstance && changes.serviceInstance.currentValue &&
+          !ctrl.watchSet) {
+
+        var context = {namespace: _.get(ctrl, 'project.metadata.name')};
+        watches.push(DataService.watch(bindingPreferredVersion, context, function(bindingsData) {
+          ctrl.watchSet = true;
+          var data = bindingsData.by('metadata.name');
+          ctrl.integratedClients = _(data).filter(function(binding) {
+            var bindingProviderName = _.get(binding, ['metadata', 'annotations', 'integrations.aerogear.org/provider']);
+            var bindingConsumerName = _.get(binding, ['metadata', 'annotations', 'integrations.aerogear.org/consumer']);
+            var serviceInstanceName = _.get(ctrl, 'serviceInstance.metadata.name');
+            return (bindingProviderName === serviceInstanceName && _.includes(ctrl.clientNames, bindingConsumerName));
+          })
+          .map(function(binding) {
+            var bindingConsumerName = _.get(binding, ['metadata', 'annotations', 'integrations.aerogear.org/consumer']);
+            return ctrl.mobileClients[bindingConsumerName];
+          })
+          .value();
+        }));
+      }
+    };
+  }
+})();

--- a/app/scripts/directives/overview/serviceInstanceRow.js
+++ b/app/scripts/directives/overview/serviceInstanceRow.js
@@ -4,6 +4,7 @@
   angular.module('openshiftConsole').component('serviceInstanceRow', {
     controller: [
       '$filter',
+      '$rootScope',
       'APIService',
       'AuthorizationService',
       'BindingService',
@@ -15,12 +16,14 @@
     bindings: {
       apiObject: '<',
       state: '<',
-      bindings: '<'
+      bindings: '<',
+      mobileClients: '<'
     },
     templateUrl: 'views/overview/_service-instance-row.html'
   });
 
   function ServiceInstanceRow($filter,
+                              $rootScope,
                               APIService,
                               AuthorizationService,
                               BindingService,
@@ -31,6 +34,8 @@
     var isBindingReady = $filter('isBindingReady');
     var serviceInstanceFailedMessage = $filter('serviceInstanceFailedMessage');
     var truncate = $filter('truncate');
+
+    row.isMobileEnabled = $rootScope.AEROGEAR_MOBILE_ENABLED;
 
     _.extend(row, ListRowUtils.ui);
 
@@ -69,6 +74,9 @@
       row.servicePlan = getServicePlan();
       row.displayName = serviceInstanceDisplayName(row.apiObject, row.serviceClass);
       row.isBindable = BindingService.isServiceBindable(row.apiObject, row.serviceClass, row.servicePlan);
+      if (row.isMobileEnabled) {
+        row.hasMobileClients = !_.isEmpty(row.mobileClients);
+      }
     };
 
     row.$onChanges = function(changes) {

--- a/app/scripts/filters/mobile.js
+++ b/app/scripts/filters/mobile.js
@@ -1,0 +1,9 @@
+'use strict';
+
+angular.module('openshiftConsole')
+  .filter('isMobileService', function() {
+    return function(serviceClass) {
+      var tags = _.get(serviceClass, 'spec.tags');
+      return _.includes(tags, 'mobile-service');
+    };
+  });

--- a/app/styles/_mobile-service-client-integrations.less
+++ b/app/styles/_mobile-service-client-integrations.less
@@ -1,0 +1,37 @@
+.mobile-service-clients-integrations {
+  .client-title {
+    border-bottom: none;
+  }
+
+  .mobile-client-integration {
+    height: 60px;
+    margin-bottom: 1em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    .client-icon {
+      display: inline-block;
+      line-height: 42px;
+      vertical-align: bottom;
+    }
+
+    .client-details {
+      display: inline-block;
+
+      .client-type {
+        .text-muted();
+        font-size: 11px;
+        line-height: 11px;
+        padding-left: 10px;
+      }
+    }
+
+    a {
+      padding-left: 10px;
+      text-overflow: ellipsis;
+      vertical-align: middle;
+      white-space: nowrap;
+    }
+  }
+}

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -34,6 +34,7 @@
 @import "_layouts.less";
 @import "_list-pf.less";
 @import "_list-view.less";
+@import "_mobile-service-client-integrations.less";
 @import "_monitoring.less";
 @import "_navbar-vertical.less";
 @import "_overlay-forms.less";

--- a/app/views/directives/mobile-service-clients.html
+++ b/app/views/directives/mobile-service-clients.html
@@ -1,0 +1,12 @@
+<div class="row mobile-service-clients-integrations">
+  <div class="col-sm-6">
+    <div class="client-title component-label section-label">Mobile Clients</div>
+    <div ng-repeat="mobileClient in $ctrl.integratedClients track by (mobileClient | uid)" class="col-sm-12 col-md-6 mobile-client-integration">
+      <span aria-hidden="true" class="fa-2x {{mobileClient.metadata.annotations.icon}} client-icon"></span>
+      <div class="client-details">
+        <a ng-href="{{mobileClient | navigateResourceURL}}">{{mobileClient.spec.name}}</a>
+        <div class="client-type">{{mobileClient.spec.appIdentifier}}</div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/overview.html
+++ b/app/views/overview.html
@@ -409,7 +409,8 @@
                   ng-repeat="serviceInstance in overview.filteredServiceInstances track by (serviceInstance | uid)"
                   api-object="serviceInstance"
                   bindings="overview.bindingsByInstanceRef[serviceInstance.metadata.name]"
-                  state="overview.state"></service-instance-row>
+                  state="overview.state"
+                  mobile-clients="overview.mobileClients"></service-instance-row>
               </div>
             </div>
           </div>

--- a/app/views/overview/_service-instance-row.html
+++ b/app/views/overview/_service-instance-row.html
@@ -152,11 +152,21 @@
                 expandable="true"
                 linkify="true">
               </truncate-long-text></p>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-sm-12">
             <div ng-if="row.serviceClass.spec.externalMetadata.documentationUrl || row.serviceClass.spec.externalMetadata.supportUrl">
               <a ng-if="row.serviceClass.spec.externalMetadata.documentationUrl" ng-href="{{row.serviceClass.spec.externalMetadata.documentationUrl}}" target="_blank" class="learn-more-link">View Documentation <i class="fa fa-external-link" aria-hidden="true"></i></a>
               <a ng-if="row.serviceClass.spec.externalMetadata.supportUrl" ng-href="{{row.serviceClass.spec.externalMetadata.supportUrl}}" target="_blank" class="learn-more-link">Get Support <i class="fa fa-external-link" aria-hidden="true"></i></a>
             </div>
           </div>
+        </div>
+        <div ng-if="row.isMobileEnabled && row.hasMobileClients && (row.serviceClass | isMobileService)">
+          <mobile-service-clients ng-if="row.apiObject | isServiceInstanceReady"
+            mobile-clients="row.mobileClients"
+            service-instance="row.apiObject"
+            project="row.state.project"></mobile-service-clients>
         </div>
       </div>
       <div class="expanded-section">


### PR DESCRIPTION
**Description**
Add a new section to the service instance view to show available mobile clients.

Based on this screen shot:
https://redhat.invisionapp.com/share/3METBQE2D#/screens/278322075

![new-service-client-integartions](https://user-images.githubusercontent.com/22113654/39195580-0d37e832-47d8-11e8-9bec-187481977604.png)

# Verification
The integrations is now determined to exist is a binding with the correct bindings exists.
So to add a client to a service:
- Create a binding.
- Edit the binding to have an annotation like this:
```
metadata:
  annotations:
    integrations.aerogear.org/consumer: my-app-id // e.g. my-cordova-cordova
    integrations.aerogear.org/provider: <service-instance-id
```

To delete, delete the binding.

The removal takes  a while as the unbind has to play out