### PR TITLE
[fix] do not parse json when config is undefined

### DIFF
--- a/app/scripts/directives/mobileClientConfig.js
+++ b/app/scripts/directives/mobileClientConfig.js
@@ -33,7 +33,7 @@ var getServiceConfig = function(secrets, SecretsService) {
       name: _.get(decodedData, 'name'),
       type: decodedData.type,
       url: decodedData.uri,
-      config: JSON.parse(decodedData.config)
+      config: decodedData.config ? JSON.parse(decodedData.config) : {}
     };
   });
 };


### PR DESCRIPTION
## Description
The config should not be parsed when it's not defined. This causes this service's config not to show up in the client config component

## Progress
- [x] Do not parse if config is not defined.

