### PR TITLE
Autopopulate binding params

### DIFF
--- a/app/scripts/directives/mobileClientBinding.js
+++ b/app/scripts/directives/mobileClientBinding.js
@@ -15,13 +15,6 @@
   function MobileClientBinding() {
     var ctrl = this;
 
-    ctrl.$onInit = function() {
-      ctrl.consumerInstance = ctrl.mobileClient;
-      ctrl.parameterData = {
-        CLIENT_ID: _.get(ctrl.mobileClient, 'metadata.name')
-      };
-    };
-
     ctrl.$onChanges = function(changes) {
       if (changes.mobileClient && changes.mobileClient.currentValue) {
         ctrl.consumerInstance = ctrl.mobileClient;

--- a/app/scripts/directives/mobileServiceBinding.js
+++ b/app/scripts/directives/mobileServiceBinding.js
@@ -51,9 +51,6 @@
           return serviceInstanceID === _.get(ctrl, 'consumerService.spec.externalID');
         });
         ctrl.consumerServiceName = _.get(ctrl.consumerSecret, 'metadata.labels.serviceName');
-        ctrl.parameterData = {
-          CLIENT_ID: ctrl.consumerServiceName
-        };
       }));
 
       watches.push(DataService.watch(instancePreferredVersion, ctrl.context, function(serviceInstancesData) {


### PR DESCRIPTION
Ticket: https://issues.jboss.org/browse/AEROGEAR-2413

Removing the hard coded `CLIENT_ID` param and replacing with values retrieved from the `servicePlan`.
Values can be set now entirely from the APB. Example of expected format here -> https://github.com/aerogearcatalog/keycloak-apb/pull/84

### Client -> Keycloak
![client-autofill](https://user-images.githubusercontent.com/22113654/39764094-c456458c-52d6-11e8-8a1e-57c1613f5aaf.png)
### Service -> Keycloak
![service-autofill](https://user-images.githubusercontent.com/22113654/39764115-d1ae8df2-52d6-11e8-98a2-65a35edeabbf.png)
