### PR TITLE
implement mobile services on mar view

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -376,6 +376,8 @@
         <script src="scripts/directives/serviceBinding.js"></script>
         <script src="scripts/directives/dropdownItem.js"></script>
         <script src="scripts/directives/optionalLink.js"></script>
+        <script src="scripts/directives/mobileServiceInstanceList.js"></script>
+        <script src="scripts/directives/mobileServiceInstanceRow.js"></script>
         <script src="scripts/directives/overview/mobileClientRow.js"></script>
         <script src="scripts/directives/overview/virtualMachineRow.js"></script>
 

--- a/app/scripts/directives/bindService.js
+++ b/app/scripts/directives/bindService.js
@@ -17,7 +17,9 @@
     bindings: {
       target: '<',
       project: '<',
-      onClose: '<'
+      onClose: '<',
+      parameterData: '<',
+      bindingMeta: '<'
     },
     templateUrl: 'views/directives/bind-service.html'
   });
@@ -193,7 +195,7 @@
       ctrl.serviceSelection = {};
       ctrl.projectDisplayName = $filter('displayName')(ctrl.project);
       ctrl.podPresets = enableTechPreviewFeature('pod_presets');
-      ctrl.parameterData = {};
+      ctrl.parameterData = ctrl.parameterData || {};
 
       ctrl.steps = [ bindFormStep, bindParametersStep, resultsStep ];
       ctrl.hideBack = bindParametersStep.hidden;
@@ -242,7 +244,7 @@
       };
 
       var serviceClass = BindingService.getServiceClassForInstance(svcToBind, ctrl.serviceClasses);
-      BindingService.bindService(svcToBind, application, serviceClass, ctrl.parameterData).then(function(binding){
+      BindingService.bindService(svcToBind, application, serviceClass, ctrl.parameterData, ctrl.bindingMeta).then(function(binding){
         ctrl.binding = binding;
         ctrl.error = null;
 

--- a/app/scripts/directives/mobileServiceInstanceList.js
+++ b/app/scripts/directives/mobileServiceInstanceList.js
@@ -1,0 +1,53 @@
+'use strict';
+
+(function() {
+  angular.module('openshiftConsole').component('mobileServiceInstanceList', {
+    controller: [
+      '$filter',
+      '$routeParams',
+      '$scope',
+      'APIService',
+      'AuthorizationService',
+      'BindingService',
+      'DataService',
+      'Navigate',
+      MobileServiceInstanceList
+    ],
+    controllerAs: 'ctrl',
+    bindings: {
+    },
+    templateUrl: 'views/_mobile-service-instance-list.html'
+  });
+
+  function MobileServiceInstanceList($filter,
+                              $routeParams,
+                              $scope,
+                              APIService,
+                              AuthorizationService,
+                              BindingService,
+                              DataService,
+                              Navigate) {
+    var ctrl = this;
+    ctrl.state = ctrl.state || {};
+    var watches = [];
+
+    $scope.$on('$destroy', function(){
+        DataService.unwatchAll(watches);
+    });
+
+    ctrl.goToCatalog = function() {
+      Navigate.toProjectCatalog(ctrl.projectName, {category: 'mobile', subcategory: 'services'});
+    };  
+
+    watches.push(DataService.watch(APIService.getPreferredVersion("clusterserviceclasses"), {namespace: $routeParams.project}, function(serviceClasses){
+      ctrl.serviceClasses = serviceClasses.by("metadata.name");
+      watches.push(DataService.watch(APIService.getPreferredVersion("serviceinstances"), {namespace: $routeParams.project}, function(serviceInstances){
+        ctrl.serviceInstances = _.filter(serviceInstances.by('metadata.name'), function(serviceInstance){
+          return $filter('isMobileService')(ctrl.serviceClasses[serviceInstance.spec.clusterServiceClassRef.name]) && 
+          $filter('isServiceInstanceReady')(serviceInstance);
+        });
+      }));
+    }));
+    
+  }
+})();

--- a/app/scripts/directives/mobileServiceInstanceRow.js
+++ b/app/scripts/directives/mobileServiceInstanceRow.js
@@ -1,0 +1,120 @@
+'use strict';
+
+(function() {
+  angular.module('openshiftConsole').component('mobileServiceInstanceRow', {
+    controller: [
+      '$filter',
+      '$routeParams',
+      '$scope',
+      'APIService',
+      'AuthorizationService',
+      'BindingService',
+      'DataService',
+      'ListRowUtils',
+      MobileServiceInstanceRow
+    ],
+    controllerAs: 'row',
+    bindings: {
+        apiObject: '<',
+        serviceClass: '<',
+        state: '<'
+    },
+    templateUrl: 'views/_mobile-service-instance-row.html'
+  });
+
+  function MobileServiceInstanceRow($filter,
+                              $routeParams,
+                              $scope,
+                              APIService,
+                              AuthorizationService,
+                              BindingService,
+                              DataService,
+                              ListRowUtils) {
+    var row = this;
+    var serviceInstanceDisplayName = $filter('serviceInstanceDisplayName');
+    row.serviceBindingsVersion = APIService.getPreferredVersion('servicebindings');
+    row.state = row.state || {};
+    var annotationSpace = "org.aerogear.binding." + this.apiObject.metadata.name;
+    var watches = [];
+    var bindingsWatch = false;
+    row.bindingsLimit = _.get(row.serviceClass, "spec.externalMetadata.bindingsLimit", 1);
+    _.extend(row, ListRowUtils.ui);
+
+    $scope.$on('$destroy', function(){
+        DataService.unwatchAll(watches);
+        DataService.unwatch(bindingsWatch);
+    });
+
+    watches.push(DataService.watchObject(APIService.getPreferredVersion('mobileclients'), $routeParams.mobileclient, {namespace: $routeParams.project}, function(mobileClient) {
+        row.mobileClient = mobileClient;
+
+        row.bindingMeta = {
+          generateName: _.get(row, 'mobileClient.metadata.name').toLowerCase() + '-' + _.get(row, 'serviceClass.spec.externalMetadata.displayName').toLowerCase() + '-',
+          annotations: {
+            'binding.aerogear.org/consumer': _.get(row, 'mobileClient.metadata.name'),
+            'binding.aerogear.org/provider': _.get(row, 'apiObject.metadata.name')
+          }
+        };
+        
+        row.annotations = _.filter(row.mobileClient.metadata.annotations, function(annotation, name){
+          return name.split("/")[0] === annotationSpace;
+        })
+        .map(JSON.parse)
+        .sort(function(a, b) {
+          if (a.label < b.label) {
+            return -1;
+          }
+          if (a.label > b.label) {
+            return 1;
+          }
+          return 0;
+        });
+
+        row.servicePlanPromise = DataService.list(APIService.getPreferredVersion('clusterserviceplans'), {}, function(servicePlans) {
+          var servicePlanData = servicePlans.by('metadata.name');
+          row.providerServicePlan = _.find(servicePlanData, function(plan) {
+            return row.serviceClass.metadata.name === plan.spec.clusterServiceClassRef.name;
+          });
+          var kind = row.mobileClient.kind.toLowerCase();
+          var bindDataPath = 'providerServicePlan.spec.externalMetadata.' + kind + '_bind_parameters_data';
+          var bindData = _.get(row, bindDataPath, []);
+          row.bindData = _(bindData).map(JSON.parse).value();
+        });
+
+        if(!bindingsWatch){
+          bindingsWatch = DataService.watch(APIService.getPreferredVersion("servicebindings"), {namespace: $routeParams.project}, function(bindings){
+            row.bindings = _.filter(bindings.by("metadata.name"), function(binding){
+              return _.get(binding.metadata.annotations, "binding.aerogear.org/consumer") === row.mobileClient.metadata.name &&
+                    _.get(binding.metadata.annotations, "binding.aerogear.org/provider") === row.apiObject.metadata.name;
+            });
+      
+            row.bindingInProgress = _.sumBy(row.bindings, function(binding){
+              return $filter('isBindingReady')(binding) ? 0 : 1;
+            });
+          });
+        }
+    }));
+
+    row.$onChanges = function() {
+      row.displayName = serviceInstanceDisplayName(row.apiObject, row.serviceClass);
+    };
+
+    row.closeOverlayPanel = function() {
+      _.set(row, 'overlay.panelVisible', false);
+    };
+
+    row.showOverlayPanel = function(panelName, state) {
+      row.parameterData = _.reduce(row.bindData, function(acc, current) {
+        if (current.type === 'path') {
+          acc[current.name] = _.get(row, 'mobileClient.' + current.value);
+        } else if (current.type === 'default') {
+          acc[current.name] = current.value;
+        }
+        return acc;
+      },{});
+      _.set(row, 'overlay.panelVisible', true);
+      _.set(row, 'overlay.panelName', panelName);
+      _.set(row, 'overlay.state', state);
+    };
+  }
+})();

--- a/app/scripts/filters/mobile.js
+++ b/app/scripts/filters/mobile.js
@@ -3,8 +3,7 @@
 angular.module('openshiftConsole')
   .filter('isMobileService', function() {
     return function(serviceClass) {
-      // Get the service tags and check if it's tagged as a mobile-service
       var tags = _.get(serviceClass, 'spec.tags');
-      return _.includes(tags, 'mobile-service') ;
+      return _.includes(tags, 'mobile-service');
     };
   });

--- a/app/styles/_mobile-clients.less
+++ b/app/styles/_mobile-clients.less
@@ -1,6 +1,42 @@
-.mobile-clients-view .copy-to-clipboard {
-  margin-bottom: 25px;
-  pre {
-    max-height: 350px;
+.mobile-clients-view {
+  .copy-to-clipboard {
+    margin-bottom: 25px;
+    pre {
+      max-height: 350px;
+    }
+  }
+  .create-binding {
+    text-align: center;
+    .note {
+      font-size: 1.3em;
+    }
+  }  
+  .note {
+    text-align: center;
+  }
+}
+
+.overview {
+  .icon {
+    clear: both;
+    color: #888;
+    font-size: 2em;
+    margin: auto;
+  }
+  .list-pf-name {
+    h3 {
+      .logo {
+        width: 30px;
+        height: 30px;
+        margin: 0 10px;
+        display: block;
+        float: left;
+        font-size: 1.6em;
+        img {
+          width: inherit;
+          height: inherit;
+        }
+      }
+    }
   }
 }

--- a/app/views/_mobile-service-instance-list.html
+++ b/app/views/_mobile-service-instance-list.html
@@ -1,0 +1,15 @@
+
+<div class="overview" ng-if="(ctrl.serviceInstances | size)">
+    <div class="list-pf">
+        <mobile-service-instance-row
+            ng-repeat="serviceInstance in ctrl.serviceInstances track by (serviceInstance | uid)"
+            api-object="serviceInstance" 
+            service-class="ctrl.serviceClasses[serviceInstance.spec.clusterServiceClassRef.name]">>
+        </mobile-service-instance-row>
+    </div>
+</div>
+
+<div class="note" ng-if="!(ctrl.serviceInstances | size)">
+    <p>Provision a mobile service to integrate it with your mobile client.</p>
+    <button class="btn btn-primary btn-lg" ng-click="ctrl.goToCatalog()">Browse Catalog</button>
+</div>

--- a/app/views/_mobile-service-instance-row.html
+++ b/app/views/_mobile-service-instance-row.html
@@ -1,0 +1,76 @@
+<div class="list-pf-item provisioned-service" ng-class="{ active: row.expanded }">
+  <div class="list-pf-container" ng-click="row.toggleExpand($event)">
+    <div class="list-pf-chevron">
+      <div ng-include src=" 'views/overview/_list-row-chevron.html' " class="list-pf-content"></div>
+    </div>
+    <div class="list-pf-content">
+      <div class="list-pf-name">
+        <h3>
+          <span class="logo" ng-if="row.serviceClass.spec.externalMetadata.imageUrl">
+            <img src="{{row.serviceClass.spec.externalMetadata.imageUrl}}">
+          </span>
+          <span class="logo {{row.serviceClass.spec.externalMetadata['console.openshift.io/iconClass']}}" ng-if="row.serviceClass.spec.externalMetadata['console.openshift.io/iconClass'] && !row.serviceClass.spec.externalMetadata.imageUrl"></span>
+          <a ng-href="{{row.apiObject | navigateResourceURL}}" ng-bind-html="row.displayName | highlightKeywords : row.state.filterKeywords"></a>
+          <div ng-bind-html="row.apiObject.metadata.name | highlightKeywords : row.state.filterKeywords" class="list-row-longname"></div>
+        </h3>
+      </div>
+    </div>
+    <span class="pficon-info icon" ng-if="((row.bindings | size) === 0)"></span>
+    <div class="list-pf-actions">
+      <div class="dropdown-kebab-pf" uib-dropdown ng-if="row.bindingInProgress == false && !(row.apiObject.metadata.deletionTimestamp) && ((row.serviceBindingsVersion | canI : 'create') || (row.serviceBindingsVersion | canI : 'delete'))">
+        <button uib-dropdown-toggle class="btn btn-link dropdown-toggle">
+          <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
+          <span class="sr-only">Actions</span>
+        </button>
+        <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu">
+          <li role="menuitem" ng-if="((row.bindings | size) < row.bindingsLimit) && (row.serviceBindingsVersion | canI : 'create')">
+            <a href="" ng-click="row.showOverlayPanel('bindService', {target: row.apiObject})">
+              Create Binding
+            </a>
+          </li>
+          <li role="menuitem" ng-if="((row.bindings | size) > 0)  && (row.serviceBindingsVersion | canI : 'delete')">
+            <a href="" ng-click="row.showOverlayPanel('unbindService', {target: row.apiObject})">Delete Binding</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="list-pf-expansion collapse" ng-if="row.expanded" ng-class="{ in: row.expanded }">
+    <div class="list-pf-container">
+      <div class="expanded-section no-margin">
+        <h4 ng-if="(row.bindings | size) && row.bindingInProgress == false" class="component-label section-label">Details</h4>
+        <ul ng-if="(row.bindings | size) && row.bindingInProgress == false">
+          <li ng-if="row.serviceClass.spec.externalMetadata.documentationUrl | size">
+            <b>Documentation</b>:
+            <a href="{{row.serviceClass.spec.externalMetadata.documentationUrl}}">SDK Setup
+              <i class="fa fa-external-link" aria-hidden="true"></i>
+            </a>
+          </li>
+          <li ng-repeat="annotation in row.annotations">
+            <b>{{annotation.label}}</b>:
+            <a ng-if="annotation.type === 'href'" href="{{annotation.value}}">{{ annotation.value }}</a>
+            <span ng-if="annotation.type === 'string'">{{ annotation.value }}</span>
+          </li>
+        </ul>
+        <span class="note" ng-if="(row.bindings | size) && (row.annotations | size) == 0 && row.bindingInProgress == false">No configuration data to show for this service.</span>
+        <div ng-if="((row.bindings | size) < row.bindingsLimit) && row.bindingInProgress == false" class="empty-state-message text-center">
+          <p ng-if="((row.bindings | size) === 0)">Bind to this service to use it in your mobile application.</p>
+          <p ng-if="((row.bindings | size) > 0)">Create further bindings to this service.</p>
+          <div class="empty-state-message-main-action">
+            <button class="btn btn-primary btn-lg" ng-click="row.showOverlayPanel('bindService', {target: row.apiObject})">Create Binding</button>
+          </div>
+        </div>
+        <div ng-if="row.bindingInProgress == true && row.expanded" class="spinner spinner-lg" aria-hidden="true"></div>
+      </div>
+    </div>
+  </div>
+</div>
+<overlay-panel show-panel="row.overlay.panelVisible" handle-close="row.closeOverlayPanel">
+  <div ng-if="row.overlay.panelName === 'bindService'">
+    <bind-service target="row.apiObject" project="row.project" on-close="row.closeOverlayPanel" parameter-data="row.parameterData"
+      binding-meta="row.bindingMeta"></bind-service>
+  </div>
+  <div ng-if="row.overlay.panelName === 'unbindService'">
+    <unbind-service target="row.apiObject" bindings="row.bindings" on-close="row.closeOverlayPanel" service-class="row.serviceClass"></unbind-service>
+  </div>
+</overlay-panel>

--- a/app/views/browse/mobile-clients.html
+++ b/app/views/browse/mobile-clients.html
@@ -73,6 +73,10 @@
                 </div>
               </div>
             </uib-tab>
+            <uib-tab active="selectedTab.mobileServices" class="mobile-services">
+              <uib-tab-heading>Mobile Services</uib-tab-heading>
+                  <mobile-service-instance-list></mobile-service-instance-list>
+            </uib-tab>
           </uib-tabset>
         </div>
       </div>


### PR DESCRIPTION
Implement mobile services overview on MAR view.

Verification:
- provision mobile client
- provision non-mobile service
- provision keycloak and custom runtime connector
- in MAR click on Mobile Services tab
-- Confirm that keycloak and custom runtime connector are visible
-- Confirm that non-mobile service is not visible
- create binding (manually add `binding.aerogear.org/consumer` `binding.aerogear.org/provider` to binding)
-- Confirm that Mobile Services tab is updated
- deprovision keycloak and custom runtime connector
-- Confirm that link to catalog is displayed in Mobile Services tab