### PR TITLE
[android-client-build] - Add create android client build form.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -259,6 +259,7 @@
         <script src="scripts/controllers/secrets.js"></script>
         <script src="scripts/controllers/secret.js"></script>
         <script src="scripts/controllers/createSecret.js"></script>
+        <script src="scripts/controllers/createClientBuild.js"></script>
         <script src="scripts/controllers/configMaps.js"></script>
         <script src="scripts/controllers/configMap.js"></script>
         <script src="scripts/controllers/createConfigMap.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -314,6 +314,10 @@ angular
         templateUrl: 'views/create-secret.html',
         controller: 'CreateSecretController'
       })
+      .when('/project/:project/create-client-build/:mobileclient', {
+        templateUrl: 'views/create-client-build.html',
+        controller: 'CreateClientBuildController'
+      })
       .when('/project/:project/browse/config-maps', {
         templateUrl: 'views/browse/config-maps.html',
         controller: 'ConfigMapsController',

--- a/app/scripts/controllers/createClientBuild.js
+++ b/app/scripts/controllers/createClientBuild.js
@@ -1,0 +1,228 @@
+'use strict';
+
+/**
+ * @ngdoc function
+ * @name openshiftConsole.controller:CreateClientBuildController
+ * @description
+ * # CreateClientBuildController
+ * Controller of the openshiftConsole
+ */
+angular.module('openshiftConsole')
+  .controller('CreateClientBuildController', function(
+    $filter,
+    $location,
+    $routeParams,
+    $scope,
+    $window,
+    APIService,
+    DataService,
+    Navigate,
+    ProjectsService,
+    SOURCE_URL_PATTERN
+  ) {
+
+    var buildConfigsVersion = APIService.getPreferredVersion('buildconfigs');
+    var secretsVersion = APIService.getPreferredVersion('secrets');
+
+    $scope.alerts = [];
+    $scope.projectName = $routeParams.project;
+    $scope.sourceURLPattern = SOURCE_URL_PATTERN;
+
+    $scope.breadcrumbs = [
+      {
+         title: 'mobile client',
+         link: 'project/' + $scope.projectName + '/browse/mobile-clients/' + $routeParams.mobileclient
+      },
+      {
+        title: 'Create client build'
+      }
+    ];
+
+    $scope.newClientBuild = {
+      authType: 'public',
+      clientType: 'android',
+      buildType: 'debug'
+    };
+    
+    $scope.buildTypeMap = {
+      android: {
+        label: 'Android',
+        buildTypes: [
+          {
+            id: 'debug',
+            label: 'Debug'
+          },
+          {
+            id: 'release',
+            label: 'Release'
+          }
+        ]
+      }
+    };
+
+    $scope.authTypes = [
+      {
+        id: 'public',
+        label: 'Public'
+      },
+      {
+        id: 'kubernetes.io/basic-auth',
+        label: 'Basic Authentication'
+      },
+      {
+        id: 'kubernetes.io/ssh-auth',
+        label: 'SSH Key'
+      }
+    ];
+
+    var createBuildConfig = function(clientConfig, secret) {
+      var buildConfig = {
+        kind: 'BuildConfig',
+        apiVersion: APIService.toAPIVersion(buildConfigsVersion),
+        metadata: {
+          name: clientConfig.buildName,
+          labels:  {
+            'mobile-client-build': 'true'
+          }
+        },
+        spec: {
+          source: {
+            git: {
+              uri: clientConfig.gitUri,
+              ref: clientConfig.gitRef
+            }
+          },
+          strategy: {
+            jenkinsPipelineStrategy: {
+              jenkinsfilePath: clientConfig.jenkinsfilePath,
+              env: [
+                {
+                  name: 'BUILD_CONFIG',
+                  value: clientConfig.buildType
+                }
+              ]
+            }
+          }
+        }
+      };
+
+      if(clientConfig.buildType === 'release') {
+        buildConfig.spec.strategy.jenkinsPipelineStrategy.env.push({name: 'BUILD_CREDENTIAL_ID', value: $scope.projectName + '-' + clientConfig.androidSecretName});
+        if(clientConfig.androidKeyStoreKeyAlias) {
+          buildConfig.spec.strategy.jenkinsPipelineStrategy.env.push({name: 'BUILD_CREDENTIAL_ALIAS', value: clientConfig.androidKeyStoreKeyAlias});
+        }
+      }
+
+      if (clientConfig.authType !== 'public') {
+        buildConfig.spec.source.sourceSecret = {
+          name: clientConfig.credentialsName
+        };
+      }
+
+      return buildConfig;
+    };
+
+    var createGitCredentialsSecret = function(clientConfig) {
+      var secret = {
+        apiVersion: APIService.toAPIVersion(secretsVersion),
+        kind: 'Secret',
+        metadata: {
+          name: clientConfig.credentialsName,
+          labels:  {
+            'mobile-client-build': 'true'
+          }
+        },
+        type: clientConfig.authType,
+        stringData: {}
+      };
+
+      switch (clientConfig.authType) {
+        case 'kubernetes.io/basic-auth':
+          secret.stringData.password = clientConfig.passwordToken;
+          secret.stringData.username = clientConfig.username;
+          secret.type = 'Opaque';
+          break;
+        case 'kubernetes.io/ssh-auth':
+          secret.stringData['ssh-privatekey'] = clientConfig.privateKey;
+          break;
+      }
+
+      return secret;
+    };
+
+    var createAndroidKeyStoreSecret = function(clientConfig) {
+      var secret = {
+        apiVersion: APIService.toAPIVersion(secretsVersion),
+        kind: 'Secret',
+        metadata: {
+          name:  clientConfig.androidSecretName,
+          labels:  {
+            'mobile-client-build': 'true',
+            'credential.sync.jenkins.openshift.io': 'true'
+          }
+        },
+        type: 'Opaque',
+        stringData: {}
+      };
+
+      var secretData =  {
+        certificate: clientConfig.androidKeyStore,
+        password: clientConfig.androidKeyStorePassword
+      };
+      // Base64 encode the values.
+      secret.data = _.mapValues(secretData, window.btoa);
+
+      return secret;
+    };
+
+    ProjectsService
+      .get($routeParams.project)
+      .then(_.spread(function(project, context) {
+        $scope.project = project;
+        $scope.context = context;
+    }));
+
+    $scope.navigateBack = function() {
+      if ($routeParams.then) {
+        $location.url($routeParams.then);
+        return;
+      }
+
+      $window.history.back();
+    };
+
+    $scope.setAdvancedOptions = function(value) {
+      $scope.advancedOptions = value;
+    };
+
+    $scope.createClientBuild = function() {
+      var clientBuildConfig = createBuildConfig($scope.newClientBuild);
+      DataService.create(buildConfigsVersion, null, clientBuildConfig, $scope.context)
+        .then(function() {
+          if ($scope.newClientBuild.authType === 'public') {
+            return Promise.resolve();
+          }
+
+          var gitSecret = createGitCredentialsSecret($scope.newClientBuild);
+          return DataService.create(secretsVersion, null, gitSecret, $scope.context);
+        })
+        .then(function() {
+          if ($scope.newClientBuild.buildType === 'debug') {
+            return Promise.resolve();
+          }
+
+          var certSecret = createAndroidKeyStoreSecret($scope.newClientBuild);
+          return DataService.create(secretsVersion, null, certSecret, $scope.context)
+        })
+        .then(function() {
+          $scope.navigateBack();
+        })
+        .catch(function(err) {
+          $scope.alerts.push({
+            type: 'error',
+            message: 'An error occured while creating the mobile client build.',
+            details: $filter('getErrorDetails')(err)
+          });
+        });
+    };
+  });

--- a/app/scripts/controllers/mobileClients.js
+++ b/app/scripts/controllers/mobileClients.js
@@ -20,6 +20,9 @@ angular.module('openshiftConsole')
     VALID_URL_PATTERN
   ) {
       var ctrl = this;
+      var serviceInstanceVersion = APIService.getPreferredVersion('serviceinstances');
+      var isServiceInstanceReady = $filter('isServiceInstanceReady');
+
       var watches = [];
       ctrl.projectName = $routeParams.project;
       ctrl.emptyMessage = 'Loading...';
@@ -73,6 +76,15 @@ angular.module('openshiftConsole')
                 }
                 ctrl.mobileClient = mobileClient;
               }));
+
+              watches.push(DataService.watch(serviceInstanceVersion, context, function (serviceInstances) {
+                $scope.serviceInstances = serviceInstances.by("metadata.name");
+                ctrl.mobileCIEnabled = _.some($scope.serviceInstances, function(serviceInstance) {
+                  console.log(serviceInstance.metadata.name + " :: ready = " + isServiceInstanceReady(serviceInstance));
+                  return /aerogear-digger/.test(serviceInstance.metadata.name) && isServiceInstanceReady(serviceInstance);
+                });
+              }));
+
             }),
             function(e) {
               ctrl.loaded = true;

--- a/app/views/browse/mobile-clients.html
+++ b/app/views/browse/mobile-clients.html
@@ -14,6 +14,9 @@
                class="dropdown-toggle actions-dropdown-kebab visible-xs-inline"
                data-toggle="dropdown"><i class="fa fa-ellipsis-v" aria-hidden="true"></i><span class="sr-only">Actions</span></a>
             <ul class="dropdown-menu dropdown-menu-right actions action-button">
+              <li ng-if="ctrl.mobileCIEnabled && ctrl.mobileClient.spec.clientType == 'android'">
+                <a ng-href="project/{{ctrl.project.metadata.name}}/create-client-build/{{ctrl.mobileClient.metadata.name}}" role="button">Create Build</a>
+              </li>
               <li>
                 <a ng-href="{{ctrl.mobileClient | editYamlURL}}" role="button">Edit YAML</a>
               </li>

--- a/app/views/create-client-build.html
+++ b/app/views/create-client-build.html
@@ -1,0 +1,314 @@
+<div class="middle surface-shaded">
+  <div class="middle-content">
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-md-10">
+          <div ng-if="!project" class="mar-top-md">Loading...</div>
+          <div ng-if="project">
+            <breadcrumbs breadcrumbs="breadcrumbs"></breadcrumbs>
+            <alerts alerts="alerts"></alerts>
+            <div class="mar-top-xl">
+              <h1>Create Client Build</h1>
+              <div class="help-block">
+                Client Build allows you to create a mobile client binary from a git source repository.
+              </div>
+              <ng-form name="clientBuildForm" class="edit-form">
+              <div class="section">
+                <dl class="dl-horizontal left">
+                  <div>
+                    <div class="row">
+                      <div class="form-group col-lg-12">
+                        <label for="clientBuildname" class="required">Name</label>
+
+                        <div ng-class="{
+                                'has-error': clientBuildForm.clientBuildname.$touched && clientBuildForm.clientBuildname.$error.required
+                              }">
+                          <input class="form-control"
+                                 id="clientBuildname"
+                                 name="clientBuildname"
+                                 type="text"
+                                 ng-model="newClientBuild.buildName"
+                                 autocorrect="off"
+                                 autocapitalize="none"
+                                 spellcheck="false"
+                                 required>
+                        </div>
+                        <div class="help-block">
+                          A name for the build
+                        </div>
+                        <div class="has-error" ng-if="clientBuildForm.clientBuildname.$touched && clientBuildForm.clientBuildname.$error.required">
+                          <span class="help-block">A name for the build is required.</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </dl>
+              </div>
+
+                <div class="section">
+                <h3 class="with-divider">Source Configuration</h3>
+                  <dl class="dl-horizontal left">
+                    <div>
+                      <div class="row">
+
+                        <div ng-class="{
+                          'col-lg-8': advancedOptions,
+                          'col-lg-12': !advancedOptions}">
+
+                          <div class="form-group">
+                            <label for="sourceUrl" class="required">Git Repository URL</label>
+                            <div ng-class="{
+                              'has-warning': clientBuildForm.sourceUrl.$touched && !sourceURLPattern.test(newClientBuild.gitUri),
+                              'has-error': clientBuildForm.sourceUrl.$touched && clientBuildForm.sourceUrl.$error.required
+                            }">
+                              <!-- Unfortunately, we can't set type="url" because some valid values don't pass browser validation. -->
+                              <input class="form-control"
+                                id="sourceUrl"
+                                name="sourceUrl"
+                                ng-model="newClientBuild.gitUri"
+                                type="text"
+                                autocorrect="off"
+                                autocapitalize="none"
+                                spellcheck="false"
+                                aria-describedby="source-url-help"
+                                required>
+                            </div>
+                            <div class="help-block" id="source-url-help">
+                              Git URL of the source code to build.
+                            </div>
+                            <div class="help-block" id="source-url-help">
+                              <span ng-if="!advancedOptions">View the <a href="" ng-click="setAdvancedOptions(true)">advanced options</a></span>
+                            </div>
+                            <div class="has-error" ng-if="clientBuildForm.sourceUrl.$touched && clientBuildForm.sourceUrl.$error.required">
+                              <span class="help-block">A Git repository URL is required.</span>
+                            </div>
+                            <div class="has-warning" ng-if="newClientBuild.gitUri && clientBuildForm.sourceUrl.$touched && !sourceURLPattern.test(newClientBuild.gitUri)">
+                              <span class="help-block">This might not be a valid Git URL. Check that it is the correct URL to a remote Git repository.</span>
+                            </div>
+                          </div>
+
+                        </div>
+                        <div class="col-lg-4" ng-if="advancedOptions">
+                          <div class="form-group editor">
+                            <label for="sourceRef">Git Reference</label>
+                            <div>
+                              <input class="form-control"
+                                id="sourceRef"
+                                name="sourceRef"
+                                type="text"
+                                ng-model="newClientBuild.gitRef"
+                                placeholder="master"
+                                autocorrect="off"
+                                autocapitalize="none"
+                                spellcheck="false"
+                                aria-describedby="source-ref-help">
+                            </div>
+                            <div class="help-block" id="source-ref-help">Optional branch, tag, or commit.</div>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div ng-if="advancedOptions">
+                        <div class="form-group">
+                          <label for="sourceContextDir">Jenkins file path</label>
+                          <div>
+                            <input class="form-control"
+                              id="sourceContextDir"
+                              name="sourceContextDir"
+                              type="text"
+                              ng-model="newClientBuild.jenkinsFilePath"
+                              placeholder="/"
+                              autocorrect="off"
+                              autocapitalize="none"
+                              spellcheck="false"
+                              aria-describedby="context-dir-help">
+                          </div>
+                          <div class="help-block" id="context-dir-help">Location of the JenkinsFile in the repository.</div>
+                        </div>
+                      </div>
+
+                        <div class="form-group">
+                          <div>
+                            <div class="form-group">
+                              <label for="authentification-type">Authentication Type</label>
+                              <ui-select required input-id="authentification-type" ng-model="newClientBuild.authType" search-enabled="false">
+                                <ui-select-match>{{$select.selected.label}}</ui-select-match>
+                                <ui-select-choices repeat="type.id as type in authTypes">
+                                  {{type.label}}
+                                </ui-select-choices>
+                              </ui-select>
+                            </div>
+
+                            <div ng-if="newClientBuild.authType !== 'public'" class="form-group">
+                              <label for="credentialsName" class="required">Name</label>
+                              <div ng-class="{ 'has-error' : clientBuildForm.credentialsName.$invalid && clientBuildForm.credentialsName.$touched }">
+                                <input class="form-control"
+                                  id="credentialsName"
+                                  name="credentialsName"
+                                  type="text"
+                                  ng-model="newClientBuild.credentialsName"
+                                  autocorrect="off"
+                                  autocapitalize="none"
+                                  spellcheck="false"
+                                  required>
+                              </div>
+                              <span class="help-block">A name for the credentials.</span>
+                              <div class="has-error" ng-if="clientBuildForm.credentialsName.$touched && clientBuildForm.credentialsName.$error.required">
+                                <span class="help-block">A name for the credentials is required.</span>
+                              </div>
+                            </div>
+
+                            <div ng-if="newClientBuild.authType === 'kubernetes.io/basic-auth'">
+                              <div class="form-group">
+                                <label for="username" class="required">Username</label>
+                                <div ng-class="{ 'has-error' : clientBuildForm.username.$invalid && clientBuildForm.username.$touched }">
+                                  <input class="form-control"
+                                    id="username"
+                                    name="username"
+                                    ng-model="newClientBuild.username"
+                                    type="text"
+                                    autocorrect="off"
+                                    autocapitalize="none"
+                                    spellcheck="false"
+                                    aria-describedby="username-help"
+                                    required>
+                                </div>
+                                <div class="help-block" id="username-help">
+                                  Username for Git authentication.
+                                </div>
+                                <div class="has-error" ng-if="clientBuildForm.username.$touched && clientBuildForm.username.$error.required">
+                                  <span class="help-block">A username is required.</span>
+                                </div>
+                              </div>
+
+                              <div class="form-group" ng-class="{ 'has-error' : clientBuildForm.passwordToken.$invalid && clientBuildForm.passwordToken.$touched }">
+                                <label class="required" for="password-token">Password or Token</label>
+                                <input class="form-control"
+                                  id="password-token"
+                                  name="passwordToken"
+                                  ng-model="newClientBuild.passwordToken"
+                                  autocorrect="off"
+                                  autocapitalize="none"
+                                  spellcheck="false"
+                                  aria-describedby="password-token-help"
+                                  type="password"
+                                  required>
+                              </div>
+                              <div class="has-error" ng-show="newClientBuild.passwordToken.$error.required && clientBuildForm.passwordToken.$touched">
+                                <div class="help-block">
+                                  Password or token is required.
+                                </div>
+                              </div>
+                              <div class="help-block" id="password-token-help">
+                                Password or token for Git authentication.
+                              </div>
+                                <div class="has-error" ng-if="clientBuildForm.passwordToken.$touched && clientBuildForm.passwordToken.$error.required">
+                                  <span class="help-block">A Password or token is required.</span>
+                                </div>
+                            </div>
+
+                            <div ng-if="newClientBuild.authType === 'kubernetes.io/ssh-auth'">
+                              <div class="form-group" id="private-key">
+                                <label for="privateKey" class="required">SSH Private Key</label>
+                                <osc-file-input
+                                  id="private-key-file-input"
+                                  model="newClientBuild.privateKey"
+                                  drop-zone-id="private-key"
+                                  help-text="Upload your private SSH key file."></osc-file-input>
+                                <div ui-ace="{
+                                  theme: 'eclipse',
+                                  rendererOptions: {
+                                    fadeFoldWidgets: true,
+                                    showPrintMargin: false
+                                  }
+                                }" ng-model="newClientBuild.privateKey" class="create-secret-editor ace-bordered" id="private-key-editor" required></div>
+                                <div class="help-block">
+                                  Private SSH key file for Git authentication.
+                                </div>
+                              </div>
+                            </div>
+
+                        </div>
+
+                    </div>
+                  </dl>
+                </div>
+
+                <div class="section">
+                  <h3 class="with-divider">Build Configuration</h3>
+                  <dl class="dl-horizontal left">
+                    <div class="form-group">
+                        <label for="build-type">Build Type</label>
+                        <ui-select required input-id="build-type" ng-model="newClientBuild.buildType" search-enabled="false">
+                            <ui-select-match>{{$select.selected.label}}</ui-select-match>
+                            <ui-select-choices repeat="type.id as type in buildTypeMap[newClientBuild.clientType].buildTypes">
+                                {{type.label}}
+                            </ui-select-choices>
+                        </ui-select>
+                    </div>
+
+                    <div ng-if="newClientBuild.clientType === 'android'">
+                      <div ng-if="newClientBuild.buildType === 'release'">
+                        <div class="form-group" id="android-credentials">
+                          <label for="androidSecretName" class="required">Name</label>
+
+                          <div ng-class="{
+                                'has-error': clientBuildForm.androidSecretName.$touched && clientBuildForm.androidSecretName.$error.required
+                              }">
+                            <input class="form-control"
+                                   id="androidSecretName"
+                                   name="androidSecretName"
+                                   type="text"
+                                   ng-model="newClientBuild.androidSecretName"
+                                   autocorrect="off"
+                                   autocapitalize="none"
+                                   spellcheck="false"
+                                   required>
+                          </div>
+                          <span class="help-block">A name for the android credentials.</span>
+                          <div class="has-error" ng-if="clientBuildForm.androidSecretName.$touched && clientBuildForm.androidSecretName.$error.required">
+                            <span class="help-block">A name for the android credentials is required.</span>
+                          </div>
+
+                          <label class="required" for="androidKeystore">Android KeyStore</label>
+                          <osc-file-input
+                              id="androidKeystore"
+                              model="newClientBuild.androidKeyStore"
+                              help-text="Password protected PKCS12 file containing a key protected by the same password"
+                              read-as-binary-string="true"
+                              required="true"></osc-file-input>
+
+                          <label for="androidKeystorePassword">KeyStore Password</label>
+                          <input class="form-control" id="androidKeystorePassword" name="androidKeystorePassword" ng-model="newClientBuild.androidKeyStorePassword" type="password">
+                          <div class="help-block">
+                            Password for the PKCS12 archive and key
+                          </div>
+
+                          <label for="androidKeystoreAlias">KeyStore Alias</label>
+                          <input class="form-control" id="androidKeystore-key-alias" name="androidKeystoreAlias" ng-model="newClientBuild.androidKeyStoreKeyAlias" type="text">
+                          <div class="help-block">
+                            The entry name of the private key/certificate chain you want to use to sign your APK(s). This entry must exist in the key store uploaded. If your key store contains only one key entry, which is the most common case, you can leave this field blank.
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </dl>
+                <div>
+
+                <div class="buttons gutter-top-bottom">
+                  <button class="btn btn-primary"
+                          type="button"
+                          ng-disabled="clientBuildForm.$invalid || clientBuildForm.$pristine"
+                          ng-click="createClientBuild()">Create</button>
+                  <button class="btn btn-default"
+                          type="button"
+                          ng-click="navigateBack()">Cancel</button>
+                </div>
+              </ng-form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Re-opened due to base branch change see https://github.com/aerogear/origin-web-console/pull/41

* Create jenkins pipeline build config for android applications.
* Enable "Create Build" option only when mobile CI/CD provisioned and client type is Android

**Verification:**
- [ ] Create project with Mobile CI/CD provisioned and an android client
- [ ] Select "Create Build" from the android clients action menu
- [ ] Create a new build for a public repo, debug build type, start the pipeline and verify it completes
- [ ] Create a new build for a private repo, debug build type, start the pipeline and verify it completes
- [ ] Create a new build for a public repo, release build type, start the pipeline and verify it completes
- [ ] Create a new build for a private repo, release build type, start the pipeline and verify it completes

To create a test keystore certificate, use the following:

```
keytool -genkey -v -keystore testcert.keystore -alias testcert -keyalg RSA -keysize 2048 -validity 10000
keytool -importkeystore -srckeystore testcert.keystore -destkeystore testcert.p12 -deststoretype PKCS12 -srcalias testcert
```

**Notes:**
* Test application with a working Jenkinsfile can be found in this repo https://github.com/mikenairn/helloworld-android-gradle/tree/5xjenkinsfile