### PR TITLE
[AEROGEAR-2732] Add alert widget to mobile client overview

### DIFF
--- a/app/scripts/directives/mobileServiceInstanceRow.js
+++ b/app/scripts/directives/mobileServiceInstanceRow.js
@@ -49,7 +49,7 @@
         row.mobileClient = mobileClient;
 
         row.bindingMeta = {
-          generateName: _.get(row, 'mobileClient.metadata.name').toLowerCase() + '-' + _.get(row, 'serviceClass.spec.externalMetadata.displayName').toLowerCase() + '-',
+          generateName: _.get(row, 'mobileClient.metadata.name').toLowerCase() + '-' + _.get(row, 'serviceClass.spec.externalMetadata.serviceName').toLowerCase() + '-',
           annotations: {
             'binding.aerogear.org/consumer': _.get(row, 'mobileClient.metadata.name'),
             'binding.aerogear.org/provider': _.get(row, 'apiObject.metadata.name')

--- a/app/views/browse/mobile-clients.html
+++ b/app/views/browse/mobile-clients.html
@@ -39,7 +39,7 @@
   <div class="middle-content" persist-tab-state>
     <div class="container-fluid">
       <div ng-if="!ctrl.loaded">{{ctrl.emptyMessage}}</div>
-      <div class="row">
+      <div class="row" ng-if="ctrl.loaded">
         <div class="col-md-12" ng-class="{ 'hide-tabs' : !ctrl.mobileClient }">
           <uib-tabset>
             <uib-tab active="selectedTab.configuration">

--- a/app/views/overview/_mobile-client-row.html
+++ b/app/views/overview/_mobile-client-row.html
@@ -50,10 +50,18 @@
       </div>
       <div class="expanded-section" ng-if="(row.services | size)">
         <div class="row">
+          <div ng-if="(row.services | size)" class="col-md-8">
+            <div ng-if="!row.alertDismissed && (row.servicesNotBoundCount > 0)" class="alert alert-info alert-dismissable">
+              <button type="button" class="close" data-dismiss="alert" aria-hidden="true" ng-click="row.alertDismissed = true">
+                <span class="pficon pficon-close"></span>
+              </button>
+              <span class="pficon pficon-info"></span>
+              {{row.servicesNotBoundCount}} mobile services are not bound to this client. 
+              <a href="" ng-click="row.navigateToMobileServices()">Bind them to use with this client.</a>
+            </div>
+          </div>
           <div class="col-md-4">
             <mobile-client-config mobile-client="row.apiObject"></mobile-client-config>
-          </div>
-          <div class="col-md-8">
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description
Show an alert widget when there are mobile services available to be bound. Add a link to the mobile services tab in the mobile client view within the alert message. The widget should be dismissable and displayed again when the page reloads.

Also includes a minor fix to use the serviceName instead of the displayName for the generatedName in the annotations as this fails for the custom runtime connector.

## Progress
- [x] Add a dismissable alert widget to the mobile client overview.
- [x] Include the number of services not bound within the alert message.
- [x] Add a link to the `Mobile Services` tab in the mobile client view within the alert message.

## Verification Steps
**NOTE**: Changes from the `aerogear-mcp` branch in the `origin-web-common` and `origin-web-console` are needed for this branch.

1. Provision a mobile client.
2. Verify that the alert widget does not show in the mobile client overview screen.
3. Provision a mobile service.
4. Verify that the alert widget shows in the mobile client overview screen once the service is ready.
5. Verify that the alert widget shows the amount of services not bound to.
6. Verify that the alert widget can be dismissed.
7. Refresh the page and verify that the alert widget shows again.
8. Click on the link `Bind them to use with this client.`
9. Verify that this directs you to the `Mobile Service` tab in the mobile client view.
10. Bind the service to the mobile client.
11. Verify that the alert widget does not show in the mobile client overview.
12. Remove the service binding.
13. Verify that the alert widget shows in the mobile client overview with the correct alert message once the service binding has been removed.
14. Provision another mobile service.
15. Verify that the alert widget shows in the mobile client overview screen once the service is ready with the correct alert message.


