### PR TITLE
[AEROGEAR-2733] Add unbound/bound services chart to mobile client

### DIFF
--- a/app/scripts/directives/overview/mobileClientRow.js
+++ b/app/scripts/directives/overview/mobileClientRow.js
@@ -30,7 +30,20 @@
     var isServiceInstanceReady = $filter('isServiceInstanceReady');
     var isMobileService = $filter('isMobileService');
     var watches = [];
+    var boundServices = 'Bound Services';
+    var unboundServices = 'Unbound Services';
     row.installType = '';
+    row.config = {
+      'chartId': 'services-info',
+      'legend': {
+        'show': true,
+        'position': 'right'
+      },
+      colors: {}
+    };
+    row.config.colors[boundServices] = $.pfPaletteColors.blue;
+    row.config.colors[unboundServices] = $.pfPaletteColors.orange;
+    row.chartHeight = 80;
 
     _.extend(row, ListRowUtils.ui);
 
@@ -47,21 +60,6 @@
     row.updateServicesInfo = function() {
       if (row.services) {
         row.servicesNotBoundCount = row.services.length - row.bindings.length;
-        var boundServices = 'Bound Services';
-        var unboundServices = 'Unbound Services';
-
-        row.config = {
-          'chartId': 'services-info',
-          'legend': {
-            'show': true,
-            'position': 'right'
-          },
-          colors: {}
-        };
-
-        row.config.colors[boundServices] = '#47b0d6';
-        row.config.colors[unboundServices] = '#e6792c';
-        row.chartHeight = 80;
 
         row.data = [
           [boundServices, row.bindings.length],

--- a/app/scripts/directives/overview/mobileClientRow.js
+++ b/app/scripts/directives/overview/mobileClientRow.js
@@ -47,6 +47,26 @@
     row.updateServicesInfo = function() {
       if (row.services) {
         row.servicesNotBoundCount = row.services.length - row.bindings.length;
+        var boundServices = 'Bound Services';
+        var unboundServices = 'Unbound Services';
+
+        row.config = {
+          'chartId': 'services-info',
+          'legend': {
+            'show': true,
+            'position': 'right'
+          },
+          colors: {}
+        };
+
+        row.config.colors[boundServices] = '#47b0d6';
+        row.config.colors[unboundServices] = '#e6792c';
+        row.chartHeight = 80;
+
+        row.data = [
+          [boundServices, row.bindings.length],
+          [unboundServices, row.servicesNotBoundCount]
+        ];
       }
     };
 
@@ -96,7 +116,6 @@
         }));
       }
     };
-
 
     row.mobileclientVersion = {
       group: "mobile.k8s.io",

--- a/app/styles/_mobile-clients.less
+++ b/app/styles/_mobile-clients.less
@@ -39,4 +39,8 @@
       }
     }
   }
+  .services-chart {
+    width: 200px;
+    padding-bottom: 0.5em;
+  }
 }

--- a/app/styles/_mobile-clients.less
+++ b/app/styles/_mobile-clients.less
@@ -40,7 +40,7 @@
     }
   }
   .services-chart {
-    width: 200px;
     padding-bottom: 0.5em;
+    width: 200px;
   }
 }

--- a/app/views/overview/_mobile-client-row.html
+++ b/app/views/overview/_mobile-client-row.html
@@ -15,6 +15,7 @@
         </h3>
       </div>
     </div>
+    <span class="pficon-info icon" ng-if="!row.alertDismissed && (row.servicesNotBoundCount > 0) && !row.expanded"></span>
     <div class="list-pf-actions">
       <div class="dropdown-kebab-pf" uib-dropdown ng-if="row.actionsDropdownVisible()">
         <button uib-dropdown-toggle class="btn btn-link dropdown-toggle">

--- a/app/views/overview/_mobile-client-row.html
+++ b/app/views/overview/_mobile-client-row.html
@@ -8,9 +8,9 @@
         <h3>
           <div class="list-row-longname"><span>{{row.clientType}}</span></div>
           <!--<span class="fa-2x {{row.apiObject.metadata.annotations.icon}}"></span>-->
-          <a ng-href="{{row.apiObject | navigateResourceURL}}"><span ng-bind-html="row.apiObject.spec.name | highlightKeywords : row.state.filterKeywords"></span></a>
-
-
+          <a ng-href="{{row.apiObject | navigateResourceURL}}">
+            <span ng-bind-html="row.apiObject.spec.name | highlightKeywords : row.state.filterKeywords"></span>
+          </a>
           <div class="list-row-longname">{{row.bundleDisplay}}</div>
         </h3>
       </div>
@@ -56,8 +56,15 @@
                 <span class="pficon pficon-close"></span>
               </button>
               <span class="pficon pficon-info"></span>
-              {{row.servicesNotBoundCount}} mobile services are not bound to this client. 
+              {{row.servicesNotBoundCount}} mobile services are not bound to this client.
               <a href="" ng-click="row.navigateToMobileServices()">Bind them to use with this client.</a>
+            </div>
+            <div>
+              <div class="component-label section-label">Mobile Services</div>
+              <div class="services-chart">
+                  <pf-donut-chart config="row.config" data="row.data" chart-height="row.chartHeight"></pf-donut-chart>
+              </div>
+              <a href="" ng-click="row.navigateToMobileServices()">View All Mobile Services</a>
             </div>
           </div>
           <div class="col-md-4">


### PR DESCRIPTION
**Description**
List all bound and unbound services in a doughnut graphic

**Verification Steps**
- Provision a mobile client and a mobile service
- Donut should show up in the mobile client row once the service is successfully provisioned
- Verify that the unbound and bound services numbers are correct
- Bind the mobile app to the mobile service
- Verify that the donut has been updated correctly

**Related Jira**
[AEROGEAR-2733](https://issues.jboss.org/browse/AEROGEAR-2733)