### PR TITLE
Show better ups details in MAR view

### DIFF
--- a/app/views/_mobile-service-instance-list.html
+++ b/app/views/_mobile-service-instance-list.html
@@ -3,8 +3,8 @@
     <div class="list-pf">
         <mobile-service-instance-row
             ng-repeat="serviceInstance in ctrl.serviceInstances track by (serviceInstance | uid)"
-            api-object="serviceInstance" 
-            service-class="ctrl.serviceClasses[serviceInstance.spec.clusterServiceClassRef.name]">>
+            api-object="serviceInstance"
+            service-class="ctrl.serviceClasses[serviceInstance.spec.clusterServiceClassRef.name]">
         </mobile-service-instance-row>
     </div>
 </div>

--- a/app/views/_mobile-service-instance-row.html
+++ b/app/views/_mobile-service-instance-row.html
@@ -38,20 +38,33 @@
   <div class="list-pf-expansion collapse" ng-if="row.expanded" ng-class="{ in: row.expanded }">
     <div class="list-pf-container">
       <div class="expanded-section no-margin">
-        <h4 ng-if="(row.bindings | size) && row.bindingInProgress == false" class="component-label section-label">Details</h4>
-        <ul ng-if="(row.bindings | size) && row.bindingInProgress == false">
-          <li ng-if="row.serviceClass.spec.externalMetadata.documentationUrl | size">
-            <b>Documentation</b>:
-            <a href="{{row.serviceClass.spec.externalMetadata.documentationUrl}}">SDK Setup
-              <i class="fa fa-external-link" aria-hidden="true"></i>
-            </a>
-          </li>
-          <li ng-repeat="annotation in row.annotations">
-            <b>{{annotation.label}}</b>:
-            <a ng-if="annotation.type === 'href'" href="{{annotation.value}}">{{ annotation.value }}</a>
-            <span ng-if="annotation.type === 'string'">{{ annotation.value }}</span>
-          </li>
-        </ul>
+        <div class="row" ng-if="(row.bindings | size) && row.bindingInProgress == false">
+          <div class="col-md-6">
+            <h4 class="component-label section-label">Details</h4>
+            <dl class="dl-horizontal left">
+              <dt>Documentation</dt>
+              <dd>
+                <a href="{{row.serviceClass.spec.externalMetadata.documentationUrl}}">SDK Setup
+                  <i class="fa fa-external-link" aria-hidden="true"></i>
+                </a>
+              </dd>
+              <dt ng-repeat-start="annotation in row.annotations">{{annotation.label}}</dt>
+              <dd ng-repeat-end>
+                <a ng-if="annotation.type === 'href'" href="{{annotation.value}}">{{ annotation.text || annotation.value }}</a>
+                <span ng-if="annotation.type === 'string'">{{ annotation.value }}</span>
+              </dd>
+            </dl>
+          </div>
+          <div class="col-md-6" ng-if="row.serviceType === 'ups'">
+            <h4 class="component-label section-label">Variants</h4>
+            <dl class="dl-horizontal left">
+              <dt ng-repeat-start="variant in row.extendedAnnotations.variants">{{variant.typeLabel}}</dt>
+              <dd ng-repeat-end>
+                <a href="{{variant.url}}">{{ variant.id }}</a>
+              </dd>
+            </dl>
+          </div>
+        </div>
         <span class="note" ng-if="(row.bindings | size) && (row.annotations | size) == 0 && row.bindingInProgress == false">No configuration data to show for this service.</span>
         <div ng-if="((row.bindings | size) < row.bindingsLimit) && row.bindingInProgress == false" class="empty-state-message text-center">
           <p ng-if="((row.bindings | size) === 0)">Bind to this service to use it in your mobile application.</p>


### PR DESCRIPTION
https://issues.jboss.org/browse/AEROGEAR-2776
https://issues.jboss.org/browse/AEROGEAR-2777

Backend/configurator side: https://issues.jboss.org/browse/AEROGEAR-2850

**Provision UPS on OpenShift first, using the branch below**

See https://github.com/aerogear/ups-config-operator/pull/38

Verification:
1. Check "aerogear-mcp" branch of our "origin-web-common" fork: https://github.com/aerogear/origin-web-common/tree/aerogear-mcp
2. Build it
3. Do `bower link` there
4. Go to this PR's repo and branch and do `bower link origin-webcommon`
5. Start web console using this branch. See https://github.com/aerogear/origin-web-console#local-configuration
6. Provision an Android client on OpenShift
7. Add these annotations to "Service Binding" resource "dh-unifiedpush-apb-xxxxx-yyyyy"
```
annotations:
    binding.aerogear.org/consumer: myapp-android
    binding.aerogear.org/provider: dh-unifiedpush-apb-xxxxx
```
9. Check MAR view, "Mobile Services" tab
10. Create bindings / delete bindings

Some edge cases to test:
* When an IOS binding is created, Android variant should still be shown
* When all variants are deleted (either directly on UPS side, or on OpenShift side with deleting binding), all push related info should be deleted in the MAR view and also in the mobile client annotations.
* Delete push app on UPS side and see what happens

Screnshot:
![screenshot from 2018-05-31 14-20-30](https://user-images.githubusercontent.com/376732/40831789-955a7db0-6592-11e8-9d98-2332ab247f93.png)

If you don't want to start up the UPS side, add these annotations to mobile client:
```

1 org.aerogear.binding.dh-unifiedpush-apb-4k22f/push-application: >-
--
{"label":"Push Application","type":"href","text":"aaa",
"value":"https://ups-aaa.192.168.42.230.nip.io/#/app/5896ac3f-66cb-43be-a7e9-ddcd13229b50/variants"}
 
2 org.aerogear.binding.dh-unifiedpush-apb-w9txs/ups-url: >-
{"label":"URL","type":"href","value":"https://ups-aaa.192.168.42.230.nip.io"}
 
3 org.aerogear.binding-ext-type.dh-unifiedpush-apb-w9txs: unifiedpush
 
4 org.aerogear.binding-ext.dh-unifiedpush-apb-w9txs/variants: >-
[
{"type":"Android","url":"https://ups-aaa.192.168.42.230.nip.io/#/app/5896ac3f-66cb-43be-a7e9-ddcd13229b50/variants/5c4ce821-efcc-4585-a9f9-070edeb8d0d3", "id":"5c4ce821-efcc-4585-a9f9-070edeb8d0d3"},
{"type":"iOS",    "url":"https://ups-aaa.192.168.42.230.nip.io/#/app/5896ac3f-66cb-43be-a7e9-ddcd13229b50/variants/4635d6fb-409c-4b0d-aebc-018e028d0799", "id":"4635d6fb-409c-4b0d-aebc-018e028d0799"}
]


```