### PR TITLE
[AEROGEAR-2731] mobile client overview enhancements

### DIFF
--- a/app/scripts/directives/overview/mobileClientRow.js
+++ b/app/scripts/directives/overview/mobileClientRow.js
@@ -4,9 +4,11 @@
   angular.module('openshiftConsole').component('mobileClientRow', {
     controller: [
       '$filter',
+      '$location',
       '$routeParams',
       'APIService',
       'AuthorizationService',
+      'BuildsService',
       'DataService',
       'ListRowUtils',
       'Navigate',
@@ -21,31 +23,62 @@
     templateUrl: 'views/overview/_mobile-client-row.html'
   });
 
-  function MobileAppRow($filter, $routeParams, APIService, AuthorizationService, DataService, ListRowUtils, Navigate, ServiceInstancesService) {
+  function MobileAppRow($filter, $location, $routeParams, APIService, AuthorizationService, BuildsService, DataService, ListRowUtils, Navigate, ServiceInstancesService) {
     var row = this;
     var serviceInstancesVersion = APIService.getPreferredVersion('serviceinstances');
     var serviceClassesVersion = APIService.getPreferredVersion('clusterserviceclasses');
+    var serviceBindingsVersion = APIService.getPreferredVersion('servicebindings');
+    var buildsVersion = APIService.getPreferredVersion('builds');
     var isServiceInstanceReady = $filter('isServiceInstanceReady');
     var isMobileService = $filter('isMobileService');
+    var watches = [];
+    var boundServices = 'Bound Services';
+    var unboundServices = 'Unbound Services';
     row.installType = '';
+    row.config = {
+      'chartId': _.get(row, 'apiObject.metadata.name') + '-services-info',
+      'legend': {
+        'show': true,
+        'position': 'right'
+      },
+      colors: {}
+    };
+    row.config.colors[boundServices] = $.pfPaletteColors.blue;
+    row.config.colors[unboundServices] = $.pfPaletteColors.orange;
+    row.chartHeight = 80;
 
     _.extend(row, ListRowUtils.ui);
 
-    row.$onInit = function() {
-      row.context = {namespace: _.get(row, 'apiObject.metadata.namespace')};
-      DataService.list(serviceClassesVersion, row.context, function(serviceClasses) {
-        serviceClasses = serviceClasses.by('metadata.name');
-        DataService.watch(serviceInstancesVersion, row.context, function(serviceinstances) {
-          row.services = _.filter(serviceinstances.by('metadata.name'), function(serviceInstance){
-            var serviceClass = _.get(serviceClasses, ServiceInstancesService.getServiceClassNameForInstance(serviceInstance));
-            return isMobileService(serviceClass) && isServiceInstanceReady(serviceInstance);
-          });
-        }, { errorNotification: false });
-      });
+    row.navigateToMobileTab = function(tab) {
+      var resource = _.get(row, 'apiObject.metadata.name');
+      var kind = _.get(row, 'apiObject.kind');
+      var namespace = _.get(row, 'apiObject.metadata.namespace');
+      var opts = {
+        tab: tab
+      };
+      return Navigate.resourceURL(resource, kind, namespace, null, opts);
+    }
+
+    row.navigateToBuild = function(build) {
+      var resource = _.get(build, 'metadata.labels.buildconfig');
+      var namespace = _.get(build, 'metadata.namespace');
+      return Navigate.resourceURL(resource, BUILD_CONFIG_KIND, namespace);
+    }
+
+    row.updateServicesInfo = function() {
+      if (row.services) {
+        row.servicesNotBoundCount = row.services.length - row.bindings.length;
+
+        row.data = [
+          [boundServices, row.bindings.length],
+          [unboundServices, row.servicesNotBoundCount]
+        ];
+      }
     };
 
     row.$onChanges = function(changes) {
-      if (changes.apiObject) {
+      var apiObjectChanges = changes.apiObject && changes.apiObject.currentValue;
+      if (apiObjectChanges) {
         row.bundleDisplay = row.apiObject.spec.appIdentifier;
         row.clientType = row.apiObject.spec.clientType.toUpperCase();
         switch (row.apiObject.spec.clientType) {
@@ -60,8 +93,46 @@
             break;
         }
       }
-    };
 
+      if (apiObjectChanges && !row.context) {
+        row.context = {namespace: _.get(row, 'apiObject.metadata.namespace')};
+      }
+
+      if (apiObjectChanges && !row.serviceInstancesWatched) {
+        row.serviceInstancesWatched = true;
+        DataService.list(serviceClassesVersion, row.context, function(serviceClasses) {
+          serviceClasses = serviceClasses.by('metadata.name');
+          watches.push(DataService.watch(serviceInstancesVersion, row.context, function(serviceinstances) {
+            row.services = _.filter(serviceinstances.by('metadata.name'), function(serviceInstance){
+              var serviceClass = _.get(serviceClasses, ServiceInstancesService.getServiceClassNameForInstance(serviceInstance));
+              return isMobileService(serviceClass) && isServiceInstanceReady(serviceInstance);
+            });
+            row.updateServicesInfo();
+          }, { errorNotification: false }));
+        });
+      }
+
+      if (apiObjectChanges && !row.bindingsWatched) {
+        row.bindingsWatched = true;
+        watches.push(DataService.watch(serviceBindingsVersion, row.context, function(bindingsData) {
+          row.bindings = _.filter(bindingsData.by('metadata.name'), function(binding) {
+            return _.get(binding.metadata.annotations, 'binding.aerogear.org/consumer') === _.get(row, 'apiObject.metadata.name');
+          });
+          row.updateServicesInfo();
+        }));
+      }
+
+      if (apiObjectChanges && !row.buildsWatched) {
+        row.buildsWatched = true;
+        watches.push(DataService.watch(buildsVersion, row.context, function(buildsData) {    
+          // Filter builds by mobile client id
+          var builds = _.filter(buildsData.by('metadata.name'), function(build) {
+            return _.get(build, 'metadata.labels.mobile-client-id') === _.get(row, 'apiObject.metadata.name');
+          });
+          row.builds = BuildsService.sortBuilds(builds, true);
+        }));
+      }
+    };
 
     row.mobileclientVersion = {
       group: "mobile.k8s.io",
@@ -81,5 +152,9 @@
     row.browseCatalog = function () {
       Navigate.toProjectCatalog(row.projectName, {category: 'mobile', subcategory: 'services'});
     };
+
+    row.$onDestroy = function() {
+      DataService.unwatchAll(watches);
+    }
   }
 })();

--- a/app/styles/_mobile-clients.less
+++ b/app/styles/_mobile-clients.less
@@ -39,4 +39,22 @@
       }
     }
   }
+  .mobile-builds {
+    .row > [class^=col-] {
+      margin: 0 !important;
+    }
+
+    .status-icon {
+      &.Complete {
+        color: @build-pipeline-success-color;
+      }
+      &.Failed {
+        color: @build-pipeline-failed-color;
+      }
+    }
+  }
+  .services-chart {
+    padding-bottom: 0.5em;
+    width: 200px;
+  }
 }

--- a/app/views/browse/mobile-clients.html
+++ b/app/views/browse/mobile-clients.html
@@ -42,7 +42,7 @@
   <div class="middle-content" persist-tab-state>
     <div class="container-fluid">
       <div ng-if="!ctrl.loaded">{{ctrl.emptyMessage}}</div>
-      <div class="row">
+      <div class="row" ng-if="ctrl.loaded">
         <div class="col-md-12" ng-class="{ 'hide-tabs' : !ctrl.mobileClient }">
           <uib-tabset>
             <uib-tab active="selectedTab.configuration">

--- a/app/views/overview/_mobile-client-row.html
+++ b/app/views/overview/_mobile-client-row.html
@@ -8,13 +8,14 @@
         <h3>
           <div class="list-row-longname"><span>{{row.clientType}}</span></div>
           <!--<span class="fa-2x {{row.apiObject.metadata.annotations.icon}}"></span>-->
-          <a ng-href="{{row.apiObject | navigateResourceURL}}"><span ng-bind-html="row.apiObject.spec.name | highlightKeywords : row.state.filterKeywords"></span></a>
-
-
+          <a ng-href="{{row.apiObject | navigateResourceURL}}">
+            <span ng-bind-html="row.apiObject.spec.name | highlightKeywords : row.state.filterKeywords"></span>
+          </a>
           <div class="list-row-longname">{{row.bundleDisplay}}</div>
         </h3>
       </div>
     </div>
+    <span class="pficon-info icon" ng-if="!row.alertDismissed && (row.servicesNotBoundCount > 0) && !row.expanded"></span>
     <div class="list-pf-actions">
       <div class="dropdown-kebab-pf" uib-dropdown ng-if="row.actionsDropdownVisible()">
         <button uib-dropdown-toggle class="btn btn-link dropdown-toggle">
@@ -50,16 +51,63 @@
       </div>
       <div class="expanded-section" ng-if="(row.services | size)">
         <div class="row">
-          <div class="col-md-4">
+          <div ng-if="(row.services | size)" class="col-md-12">
+            <div ng-if="!row.alertDismissed && (row.servicesNotBoundCount > 0)" class="alert alert-info alert-dismissable">
+              <button type="button" class="close" data-dismiss="alert" aria-hidden="true" ng-click="row.alertDismissed = true">
+                <span class="pficon pficon-close"></span>
+              </button>
+              <span class="pficon pficon-info"></span>
+              {{row.servicesNotBoundCount}} mobile services are not bound to this client.
+              <a href="" ng-href="{{ row.navigateToMobileTab('mobileServices') }}">Bind them to use with this client.</a>
+            </div>
+          </div>
+          <div ng-if="(row.services | size)" class="col-md-6">
+            <div>
+              <div class="component-label section-label">Mobile Services</div>
+              <div class="services-chart">
+                <pf-donut-chart config="row.config" data="row.data" chart-height="row.chartHeight"></pf-donut-chart>
+              </div>
+              <a href="" ng-href="{{ row.navigateToMobileTab('mobileServices') }}">View All Mobile Services</a>
+            </div>
+          </div>
+          <div class="col-md-6">
             <mobile-client-config mobile-client="row.apiObject"></mobile-client-config>
           </div>
-          <div class="col-md-8">
-          </div>
         </div>
-      </div>
-      <div ng-if="loading">
-        Loading...
+        <div ng-if="(row.builds | size)">
+          <div class="component-label section-label">Mobile Builds</div>
+          <div ng-repeat="build in (row.builds | limitTo: 5) track by (build | uid)" class="mobile-builds">
+            <div class="row">
+              <div class="col-md-6">
+                <h3>
+                  <a ng-href="{{build | configURLForResource}}">{{build | buildConfigForBuild}}</a>
+                </h3>
+              </div>
+              <div class="col-md-6">
+                <span class="status-icon" ng-class="build.status.phase">
+                  <span ng-switch="build.status.phase" class="hide-ng-leave">
+                    <span ng-switch-when="Complete" aria-hidden="true">
+                      <i class="fa fa-check-circle fa-fw"></i>
+                    </span>
+                    <span ng-switch-when="Failed" aria-hidden="true">
+                      <i class="fa fa-times-circle fa-fw"></i>
+                    </span>
+                    <span ng-switch-default>
+                      <status-icon status="build.status.phase"></status-icon>
+                    </span>
+                  </span>
+                </span>
+                <a ng-href="{{build | navigateResourceURL}}">Build #{{build | annotation : 'buildNumber'}}</a>
+                <span am-time-ago="build.metadata.creationTimestamp" class="build-timestamp"></span>
+              </div>
+            </div>
+          </div>
+          <a href="" ng-href="{{ row.navigateToMobileTab('builds') }}">View All Mobile Builds</a>
+        </div>
+        </div>
+        <div ng-if="loading">
+          Loading...
+        </div>
       </div>
     </div>
   </div>
-</div>


### PR DESCRIPTION
## Description
Mobile client overview should only show an overview of the client and the things associated with it. Changes includes:
- Add an alert widget when there are mobile services available to be bound.
- Visualize the bound and unbound service in a donut graph.
- List the latests 5 builds relating to the mobile client.

## Additional Notes
Related Epic: https://issues.jboss.org/browse/AEROGEAR-2731
Related JIRA Tickets: 
- https://issues.jboss.org/browse/AEROGEAR-2732
- https://issues.jboss.org/browse/AEROGEAR-2733
- https://issues.jboss.org/browse/AEROGEAR-2734