### PR TITLE
[mobile-client-build] Fix jenkinsfile path option

### DIFF
--- a/app/scripts/controllers/createClientBuild.js
+++ b/app/scripts/controllers/createClientBuild.js
@@ -93,7 +93,7 @@ angular.module('openshiftConsole')
           },
           strategy: {
             jenkinsPipelineStrategy: {
-              jenkinsfilePath: clientConfig.jenkinsfilePath,
+              jenkinsfilePath: clientConfig.jenkinsFilePath,
               env: [
                 {
                   name: 'BUILD_CONFIG',


### PR DESCRIPTION
Can use this repo for verification https://github.com/mikenairn/android-showcase-template/tree/5xjenkinsfile-dif-dir. Set the jenkins file path to "cicd/Jenkinsfile" under advanced options.