### PR TITLE
[mobile-client-service-view] filter services by mobile client enabled tag

### DIFF
--- a/app/scripts/directives/mobileServiceInstanceList.js
+++ b/app/scripts/directives/mobileServiceInstanceList.js
@@ -43,8 +43,10 @@
       ctrl.serviceClasses = serviceClasses.by("metadata.name");
       watches.push(DataService.watch(APIService.getPreferredVersion("serviceinstances"), {namespace: $routeParams.project}, function(serviceInstances){
         ctrl.serviceInstances = _.filter(serviceInstances.by('metadata.name'), function(serviceInstance){
-          return $filter('isMobileService')(ctrl.serviceClasses[serviceInstance.spec.clusterServiceClassRef.name]) && 
-          $filter('isServiceInstanceReady')(serviceInstance);
+          var serviceInstanceName = _.get(serviceInstance, 'spec.clusterServiceClassRef.name');
+          return $filter('isMobileService')(ctrl.serviceClasses[serviceInstanceName]) && 
+                 $filter('isServiceInstanceReady')(serviceInstance) &&
+                 $filter('isMobileClientEnabled')(ctrl.serviceClasses[serviceInstanceName]);
         });
       }));
     }));

--- a/app/scripts/filters/mobile.js
+++ b/app/scripts/filters/mobile.js
@@ -6,4 +6,10 @@ angular.module('openshiftConsole')
       var tags = _.get(serviceClass, 'spec.tags');
       return _.includes(tags, 'mobile-service');
     };
+  })
+  .filter('isMobileClientEnabled', function() {
+    return function(serviceClass) {
+      var tags = _.get(serviceClass, 'spec.tags');
+      return _.includes(tags, 'mobile-client-enabled');    
+    };
   });


### PR DESCRIPTION
## Description
The mobile services view for a mobile client should only show the available mobile services that can be bound to a client. 

## Progress
- [x] Add a filter for filtering `mobile-client-enabled` services
- [x] Filter services to be listed within the mobile service tab in MAR view.

