### PR TITLE
[mobile-client-binding-annotations] set default binding meta for mobi…

### DIFF
--- a/app/scripts/directives/mobileServiceInstanceRow.js
+++ b/app/scripts/directives/mobileServiceInstanceRow.js
@@ -49,14 +49,6 @@
     watches.push(DataService.watchObject(APIService.getPreferredVersion('mobileclients'), $routeParams.mobileclient, {namespace: $routeParams.project}, function(mobileClient) {
         row.mobileClient = mobileClient;
 
-        row.bindingMeta = {
-          generateName: _.get(row, 'mobileClient.metadata.name').toLowerCase() + '-' + _.get(row, 'serviceClass.spec.externalMetadata.serviceName').toLowerCase() + '-',
-          annotations: {
-            'binding.aerogear.org/consumer': _.get(row, 'mobileClient.metadata.name'),
-            'binding.aerogear.org/provider': _.get(row, 'apiObject.metadata.name')
-          }
-        };
-
         row.annotations = _.filter(row.mobileClient.metadata.annotations, function(annotation, name){
           return name.split("/")[0] === annotationSpace;
         })

--- a/app/views/_mobile-service-instance-row.html
+++ b/app/views/_mobile-service-instance-row.html
@@ -80,8 +80,7 @@
 </div>
 <overlay-panel show-panel="row.overlay.panelVisible" handle-close="row.closeOverlayPanel">
   <div ng-if="row.overlay.panelName === 'bindService'">
-    <bind-service target="row.apiObject" project="row.project" on-close="row.closeOverlayPanel" parameter-data="row.parameterData"
-      binding-meta="row.bindingMeta"></bind-service>
+    <bind-service target="row.apiObject" project="row.project" on-close="row.closeOverlayPanel" parameter-data="row.parameterData"></bind-service>
   </div>
   <div ng-if="row.overlay.panelName === 'unbindService'">
     <unbind-service target="row.apiObject" bindings="row.bindings" on-close="row.closeOverlayPanel" service-class="row.serviceClass"></unbind-service>


### PR DESCRIPTION
## Description
Mobile service bindings created within a service instance context should be annotated with the following mobile annotations:
```
generateName: [Used for the service binding name] (i.e. myapp-android-keycloak-<hash>)
annotations: {
  'binding.aerogear.org/consumer':  <consumer service id>
  'binding.aerogear.org/provider': <provider service id>
}
```

There is no way of getting the targeted mobile client from within the service instance context apart from the `CLIENT_ID` parameter that is passed to the bind service which is populated by the user, therefore we can't pass a binding-meta [from within the service instance context](https://github.com/aerogear/origin-web-console/blob/aerogear-mcp/app/views/overview/_service-instance-row.html#L190-L192). 

Instead, we can set the bindingMeta within the bindService, as the parameterData is available [here](https://github.com/openshift/origin-web-console/blob/master/app/scripts/directives/bindService.js#L245), when the bindingMeta is not provided.

## Progress
- [x] Set binding meta with the required annotations when no bindingMeta is provided to the bindService directive.

## Additional Notes
Related JIRA Ticket - https://issues.jboss.org/browse/AEROGEAR-2902



