### PR TITLE
[mobile-client-overview] show only completed bound services

### DIFF
--- a/app/scripts/directives/overview/mobileClientRow.js
+++ b/app/scripts/directives/overview/mobileClientRow.js
@@ -29,6 +29,7 @@
     var serviceClassesVersion = APIService.getPreferredVersion('clusterserviceclasses');
     var serviceBindingsVersion = APIService.getPreferredVersion('servicebindings');
     var buildsVersion = APIService.getPreferredVersion('builds');
+    var isBindingReady = $filter('isBindingReady');
     var isServiceInstanceReady = $filter('isServiceInstanceReady');
     var isMobileClientEnabled = $filter('isMobileClientEnabled');
     var isMobileService = $filter('isMobileService');
@@ -113,7 +114,7 @@
         row.bindingsWatched = true;
         watches.push(DataService.watch(serviceBindingsVersion, row.context, function(bindingsData) {
           row.bindings = _.filter(bindingsData.by('metadata.name'), function(binding) {
-            return _.get(binding.metadata.annotations, 'binding.aerogear.org/consumer') === _.get(row, 'apiObject.metadata.name');
+            return _.get(binding.metadata.annotations, 'binding.aerogear.org/consumer') === _.get(row, 'apiObject.metadata.name') && isBindingReady(binding);
           });
           row.updateServicesInfo();
         }));


### PR DESCRIPTION
## Description
Add a filter to only include services when they've finished the binding process successfully in the donut chart information for bound services. 

## Progress
- [x] Add `isBindingReady` filter when bindings are retrieved

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/AEROGEAR-3128

**Screenshots**
![peek 2018-06-12 11-44](https://user-images.githubusercontent.com/9078522/41286071-23daae1a-6e36-11e8-8149-7051b9b4a724.gif)
