### PR TITLE
[MAR] small fixes for the mobile services view

### DIFF
--- a/app/scripts/directives/mobileServiceInstanceList.js
+++ b/app/scripts/directives/mobileServiceInstanceList.js
@@ -36,7 +36,7 @@
     });
 
     ctrl.goToCatalog = function() {
-      Navigate.toProjectCatalog(ctrl.projectName, {category: 'mobile', subcategory: 'services'});
+      Navigate.toProjectCatalog($routeParams.project, {category: 'mobile', subcategory: 'services'});
     };  
 
     watches.push(DataService.watch(APIService.getPreferredVersion("clusterserviceclasses"), {namespace: $routeParams.project}, function(serviceClasses){

--- a/app/views/_mobile-service-instance-row.html
+++ b/app/views/_mobile-service-instance-row.html
@@ -39,7 +39,7 @@
     <div class="list-pf-container">
       <div class="expanded-section no-margin">
         <div class="row" ng-if="(row.bindings | size) && row.bindingInProgress == false">
-          <div class="col-md-6">
+          <div ng-class="{'col-md-6' : (row.extendedAnnotations | size), 'col-md-12' : !(row.extendedAnnotations | size)}">
             <h4 class="component-label section-label">Details</h4>
             <dl class="dl-horizontal left">
               <dt>Documentation</dt>
@@ -55,14 +55,16 @@
               </dd>
             </dl>
           </div>
-          <div class="col-md-6" ng-if="row.serviceType === 'ups'">
-            <h4 class="component-label section-label">Variants</h4>
-            <dl class="dl-horizontal left">
-              <dt ng-repeat-start="variant in row.extendedAnnotations.variants">{{variant.typeLabel}}</dt>
-              <dd ng-repeat-end>
-                <a href="{{variant.url}}">{{ variant.id }}</a>
-              </dd>
-            </dl>
+          <div class="col-md-6" ng-if="(row.extendedAnnotations | size)">
+            <div ng-if="row.serviceType === 'ups'">
+              <h4 class="component-label section-label">Variants</h4>
+              <dl class="dl-horizontal left">
+                <dt ng-repeat-start="variant in row.extendedAnnotations.variants">{{variant.typeLabel}}</dt>
+                <dd ng-repeat-end>
+                  <a href="{{variant.url}}">{{ variant.id }}</a>
+                </dd>
+              </dl>
+            </div>
           </div>
         </div>
         <span class="note" ng-if="(row.bindings | size) && (row.annotations | size) == 0 && row.bindingInProgress == false">No configuration data to show for this service.</span>
@@ -73,7 +75,7 @@
             <button class="btn btn-primary btn-lg" ng-click="row.showOverlayPanel('bindService', {target: row.apiObject})">Create Binding</button>
           </div>
         </div>
-        <div ng-if="row.bindingInProgress == true && row.expanded" class="spinner spinner-lg" aria-hidden="true"></div>
+        <div ng-class="{'spinner spinner-lg' : row.bindingInProgress == true && row.expanded}" aria-hidden="true"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description
Minor small fixes for the mobile service tab in the MAR view. Changes includes: 
- `Browse Catalog` button should navigate to the catalog within the project.
- The `Details` section label should fill the row when there is no `Variants` available
- The spinner should not show at the same time as the `Bind Service` button

## Progress
- [x] Fix `Browse Catalog` button to navigate to the catalog within the project.
- [x] Fix `Details` section label display when no variants are available
- [x] Fix spinner to not show at the same time as `Bind Service` button.

