### PR TITLE
[MAR] update mobile client breadcrumb link to navigate to resource list

### DIFF
--- a/app/scripts/controllers/mobileClients.js
+++ b/app/scripts/controllers/mobileClients.js
@@ -29,11 +29,10 @@ angular.module('openshiftConsole')
       ctrl.projectName = $routeParams.project;
       ctrl.emptyMessage = 'Loading...';
       ctrl.alerts = {};
-      ctrl.redirectUrl = Navigate.projectOverviewURL(ctrl.projectName);
       $scope.breadcrumbs = [
         {
           title: 'Mobile Clients',
-          link: ctrl.redirectUrl + '/browse/mobile-clients'
+          link: 'project/' + ctrl.projectName + '/browse/other?kind=MobileClient&group=' + mobileClientsVersion.group
         },
         {
           title: $routeParams.mobileclient


### PR DESCRIPTION
## Description
At the moment, the mobile client breadcrumb link is directing to a page that does not exist, therefore it links back to the openshift landing page. This should direct to the mobile client resource list instead (**Resource > Mobile Client**)

## Progress
- [x] update mobile client breadcrumb link to navigate to the mobile client resource list.

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/AEROGEAR-3076

**Screenshots**
![peek 2018-06-12 15-07](https://user-images.githubusercontent.com/9078522/41295519-aca812fc-6e52-11e8-85b8-94fbeb571235.gif)
