### PR TITLE
[mobile-client-build-tab] add build platform detail

### DIFF
--- a/app/scripts/controllers/createClientBuild.js
+++ b/app/scripts/controllers/createClientBuild.js
@@ -88,7 +88,8 @@ angular.module('openshiftConsole')
           labels:  {
             'mobile-client-build': 'true',
             'mobile-client-id': _.get($routeParams, 'mobileclient'),
-            'mobile-client-type': clientConfig.clientType          
+            'mobile-client-build-platform': clientConfig.buildPlatform,
+            'mobile-client-type': clientConfig.clientType      
           }
         },
         spec: {

--- a/app/views/mobile-client-builds-row.html
+++ b/app/views/mobile-client-builds-row.html
@@ -71,7 +71,7 @@
             <b>Build Platform</b>
           </div>
           <div class="col-sm-6 col-md-4">
-            
+            {{row.apiObject.metadata.labels['mobile-client-build-platform']}}
           </div>
           <div class="col-sm-6 col-md-2">
             <b>Jenkinsfile Path</b>


### PR DESCRIPTION
## Description
As per feedback, we need to include the build platform detail on the `Build Config` section within the build tab of the MAR view.

## Progress
- [x] Add `mobile-client-build-platform` label to the build config.
- [x] Show the build platform using this label

## Additional Notes
Related JIRA - https://issues.jboss.org/browse/AEROGEAR-2949

Screenshots
- Android
![image](https://user-images.githubusercontent.com/9078522/41299275-014b4d12-6e5b-11e8-8bde-34b2d3e1fe71.png)

- iOS
![image](https://user-images.githubusercontent.com/9078522/41299211-e597e026-6e5a-11e8-8ba5-f7a2b30aceb2.png)

- Cordova
![image](https://user-images.githubusercontent.com/9078522/41299374-2fb64f08-6e5b-11e8-87f7-d61dc25f36f7.png)
![image](https://user-images.githubusercontent.com/9078522/41299408-485e3df4-6e5b-11e8-8bc1-0ec78bfd2972.png)

