### PR TITLE
[mobile client build] allow for keystores that are part of android source

### DIFF
--- a/app/scripts/controllers/createClientBuild.js
+++ b/app/scripts/controllers/createClientBuild.js
@@ -45,7 +45,7 @@ angular.module('openshiftConsole')
         title: 'Create client build'
       }
     ];
-    
+
     $scope.buildTypeMap = {
       android: {
         label: 'Android',
@@ -89,7 +89,7 @@ angular.module('openshiftConsole')
             'mobile-client-build': 'true',
             'mobile-client-id': _.get($routeParams, 'mobileclient'),
             'mobile-client-build-platform': clientConfig.buildPlatform,
-            'mobile-client-type': clientConfig.clientType      
+            'mobile-client-type': clientConfig.clientType
           }
         },
         spec: {
@@ -187,7 +187,7 @@ angular.module('openshiftConsole')
       if (clientConfig.buildPlatform === 'ios') {
         secretData['developer-profile'] = clientConfig.clientCredentials;
       }
-      
+
       // Base64 encode the values.
       secret.data = _.mapValues(secretData, window.btoa);
 
@@ -239,10 +239,9 @@ angular.module('openshiftConsole')
           return DataService.create(secretsVersion, null, gitSecret, $scope.context);
         })
         .then(function() {
-          if ($scope.newClientBuild.buildType === debugBuildType.id && $scope.newClientBuild.buildPlatform === 'android') {
+          if ($scope.newClientBuild.buildPlatform === 'android' && ($scope.newClientBuild.buildType === debugBuildType.id || !$scope.newClientBuild.externalCredential)) {
             return Promise.resolve();
           }
-
           var certSecret = createClientCredentialsSecret($scope.newClientBuild);
           return DataService.create(secretsVersion, null, certSecret, $scope.context);
         })

--- a/app/views/create-client-build.html
+++ b/app/views/create-client-build.html
@@ -284,11 +284,11 @@
                           id="clientCredentials"
                           model="newClientBuild.clientCredentials"
                           read-as-binary-string="true"
-                          required="true"></osc-file-input>        
+                          required="true"></osc-file-input>
                         <div class="help-block">
                           A developer profile file (*.developerprofile) which contains a code signing private key, corresponding developer/distribution certificates, and mobile provisioning profiles.
                           For more information, see this <a target="_blank" href="https://help.apple.com/xcode/mac/8.0/#/dev8a2822e0b">documentation</a> on exporting developer accounts in XCode.
-                        </div>               
+                        </div>
 
                         <label for="clientCredentialsPassword">Apple Developer Profile Password</label>
 
@@ -303,11 +303,14 @@
                         <div class="has-error" ng-if="clientBuildForm.clientCredentialsPassword.$touched && clientBuildForm.clientCredentialsPassword.$error.required">
                           <span class="help-block">A password for the ios credentials is required.</span>
                         </div>
-                      </div>                    
+                      </div>
                     </div>
 
                     <div ng-if="newClientBuild.buildType === 'release' && newClientBuild.buildPlatform === 'android'">
-                      <div class="form-group" id="client-credentials">
+                        <div class="form-group" id="client-credentials">
+                          <input ng-model="newClientBuild.externalCredential" type="checkbox" id="upload-credential"> Upload external credentials (Use this option if your Keystore is external to your source code)
+                        </div>
+                      <div ng-if="newClientBuild.externalCredential" class="form-group" id="client-credentials">
                         <label for="clientCredentialsName" class="required">Name</label>
 
                         <div ng-class="{
@@ -334,7 +337,7 @@
                             model="newClientBuild.clientCredentials"
                             help-text="Password protected PKCS12 file containing a key protected by the same password"
                             read-as-binary-string="true"
-                            required="true"></osc-file-input>                        
+                            required="true"></osc-file-input>
 
                         <label for="clientCredentialsPassword">Android Keystore Password</label>
 


### PR DESCRIPTION
change is to add a checkbox to allow the user to select to upload a external keystore

@mikenairn 