### PR TITLE
[mobile-client-build] Add support for adding optional env vars

### DIFF
--- a/app/scripts/controllers/createClientBuild.js
+++ b/app/scripts/controllers/createClientBuild.js
@@ -131,6 +131,15 @@ angular.module('openshiftConsole')
         };
       }
 
+      if (clientConfig.envVars) {
+        _.forEach(clientConfig.envVars, function(envVar) {
+          if (envVar.name) {
+            envVar = _.omit(envVar, ['$$hashKey']);
+            buildConfig.spec.strategy.jenkinsPipelineStrategy.env.push(envVar);
+          }
+        });
+      }
+
       return buildConfig;
     };
 
@@ -208,7 +217,8 @@ angular.module('openshiftConsole')
             authType: 'public',
             clientType: clientType,
             buildType: debugBuildType.id,
-            buildPlatform: buildPlatform
+            buildPlatform: buildPlatform,
+            envVars: []
           };
         });
     }));

--- a/app/views/create-client-build.html
+++ b/app/views/create-client-build.html
@@ -355,6 +355,21 @@
                         </div>
                       </div>
                     </div>
+
+                    <div class="form-group">
+                      <label for="env-vars">Environment Variables</label>
+                      <key-value-editor
+                        entries="newClientBuild.envVars"
+                        key-placeholder="Key"
+                        value-placeholder="Value"
+                        key-validator="[A-Za-z_][A-Za-z0-9_]*"
+                        key-validator-error="Please enter a valid key"
+                        key-validator-error-tooltip="A valid environment variable name is an alphanumeric (a-z and 0-9) string beginning with a letter that may contain underscores."
+                        add-row-link="Add Environment Variable"
+                        cannot-sort
+                        show-header>
+                      </key-value-editor>                    
+                    </div>
                   </dl>
                 </div>
 


### PR DESCRIPTION
## Description
Update the client build form to add support to additional environment variables that will be made available in the Jenkinsfile.

## Progress
- [x] Add section to the client build form to add environment variables
- [x] Make these environment variables to be available in the Jenkinsfile.

## Verification Steps

1. Provision Mobile CI/CD
2. Provision a mobile client
3. Create client build (Specify an environment variable)
4. Go to the build config's yaml file.
5. Ensure that the defined environment variable can be seen under `spec.strategy.jenkinsPipelineStrategy.env`
6. Create another client build (Do not specify any environment variable)
7. Ensure that no environment variable is added to `spec.strategy.jenkinsPipelineStrategy.env`


## Additional Notes
Related JIRA Ticket - https://issues.jboss.org/browse/AEROGEAR-2814